### PR TITLE
Remove min loop according to https://github.com/euslisp/jskeus/pull/273

### DIFF
--- a/hrpsys_ros_bridge_jvrc/euslisp/4legs-walking.l
+++ b/hrpsys_ros_bridge_jvrc/euslisp/4legs-walking.l
@@ -164,7 +164,6 @@
                 :absolute-p t
                 :debug-view debug-view
                 :cog-null-space nil
-                :min-loop 2
                 :additional-weight-list (list (list (send *robot* :torso :waist-y :child-link) 0.0))
                 :root-link-virtual-joint-weight (float-vector 0.5 0.5 0.5 0.0 0.0 0.0)
                 :cog-gain 5.0 :centroid-thre 50


### PR DESCRIPTION
`min-loop`をirteusで設定したので（https://github.com/euslisp/jskeus/pull/273）消しました。
@eisoku9618, @YuOhara
:fullbody-inverse-kinematicsがはやくなります（挙動がかわることはあるかも）
