### PR TITLE
Use JAXON_RED(Robot)0 instead of JAXON_RED for simulator instance name to keep compatibility with hrpsys-simulator.

### DIFF
--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_DRCBOX.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_DRCBOX.cnoid.in
@@ -57,7 +57,7 @@ items:
                 confFileName: "@JVRC_CONF_DIRECTORY@/SensorReaderRTC_JAXON_RED.PD.conf"
                 configurationMode: Use Configuration File
                 AutoConnect: false
-                InstanceName: JAXON_RED
+                InstanceName: JAXON_RED(Robot)0
                 bodyPeriodicRate: 0.002
         - 
           id: 4

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_FLAT.cnoid.in
@@ -57,7 +57,7 @@ items:
                 confFileName: "@JVRC_CONF_DIRECTORY@/SensorReaderRTC_JAXON_RED.PD.conf"
                 configurationMode: Use Configuration File
                 AutoConnect: false
-                InstanceName: JAXON_RED
+                InstanceName: JAXON_RED(Robot)0
                 bodyPeriodicRate: 0.002
         - 
           id: 4

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_RH_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_RH_FLAT.cnoid.in
@@ -57,7 +57,7 @@ items:
                 confFileName: "@JVRC_CONF_DIRECTORY@/BodyRTC_JAXON_RED.RH.conf"
                 configurationMode: Use Configuration File
                 AutoConnect: false
-                InstanceName: JAXON_RED
+                InstanceName: JAXON_RED(Robot)0
                 bodyPeriodicRate: 0.002
         - 
           id: 4

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_VALVE.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_VALVE.cnoid.in
@@ -57,7 +57,7 @@ items:
                 confFileName: "@JVRC_CONF_DIRECTORY@/SensorReaderRTC_JAXON_RED.PD.conf"
                 configurationMode: Use Configuration File
                 AutoConnect: false
-                InstanceName: JAXON_RED
+                InstanceName: JAXON_RED(Robot)0
                 bodyPeriodicRate: 0.002
         - 
           id: 4

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
@@ -14,7 +14,7 @@
   <arg unless="$(arg USE_ROBOTHARDWARE)"
        name="taskname" value="$(arg TASK)" />
   <arg name="PROJECT_FILE" default="$(find hrpsys_choreonoid_tutorials)/config/JAXON_RED_$(arg taskname).cnoid" />
-  <arg name="SIMULATOR_NAME" default="JAXON_RED" />
+  <arg name="SIMULATOR_NAME" default="JAXON_RED(Robot)0" />
   <arg if="$(arg USE_ROBOTHARDWARE)"
        name="BRIDGE_SIMULATOR_NAME" default="RobotHardware_choreonoid0" />
   <arg unless="$(arg USE_ROBOTHARDWARE)"


### PR DESCRIPTION
Use JAXON_RED(Robot)0 instead of JAXON_RED for simulator instance name to keep compatibility with hrpsys-simulator.