### PR TITLE
Enable to connect setuplogger for CONSTRAINT_FORCE

### DIFF
--- a/hrpsys_choreonoid/launch/startup_choreonoid.launch
+++ b/hrpsys_choreonoid/launch/startup_choreonoid.launch
@@ -12,6 +12,7 @@
   <arg name="REALTIME" default="true" />
   <arg name="corbaport" default="15005" />
   <arg name="hrpsys_precreate_rtc" default=""/>
+  <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="false"/>
   <param name="use_sim_time" value="true" />
   <include file="$(find hrpsys_tools)/launch/hrpsys.launch">
     <arg name="USE_CHOREONOID" value="true" />
@@ -31,5 +32,6 @@
     <arg name="hrpsys_precreate_rtc" value="$(arg hrpsys_precreate_rtc)" />
     <arg name="HRPSYS_PY_PKG"  value="$(arg HRPSYS_PY_PKG)" />
     <arg name="HRPSYS_PY_NAME" value="$(arg HRPSYS_PY_NAME)" />
+    <arg name="HRPSYS_PY_ARGS" value="--connect-constraint-force-logger-ports" if="$(arg CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS)"/>
   </include>
 </launch>

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
@@ -29,6 +29,7 @@
        name="HRPSYS_PY_NAME" value="jaxon_red_setup.py" />
   <arg name="CONTROLLER_CONFIG"
        value="$(find hrpsys_choreonoid_tutorials)/models/JAXON_JVRC_controller_config.yaml" />
+  <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="false"/>
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
@@ -45,6 +46,7 @@
     <arg name="REALTIME" value="$(arg REALTIME)" />
     <arg name="GUI" value="$(arg GUI)" />
     <arg name="hrpsys_precreate_rtc" value="$(arg hrpsys_precreate_rtc)" />
+    <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="$(arg CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS)"/>
   </include>
   <!-- ros_bridge -->
   <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />

--- a/hrpsys_choreonoid_tutorials/scripts/jaxon_red_rh_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/jaxon_red_rh_setup.py
@@ -53,11 +53,12 @@ class JAXON_RED_HrpsysConfigurator(ChoreonoidHrpsysConfigurator):
 
 if __name__ == '__main__':
     hcf = JAXON_RED_HrpsysConfigurator("JAXON_RED")
+    [sys.argv, connect_constraint_force_logger_ports] = hcf.parse_arg_for_connect_ports(sys.argv)
     if len(sys.argv) > 2 :
-        hcf.init(sys.argv[1], sys.argv[2])
+        hcf.init(sys.argv[1], sys.argv[2], connect_constraint_force_logger_ports=connect_constraint_force_logger_ports)
         hcf.startABSTIMP()
     elif len(sys.argv) > 1 :
-        hcf.init(sys.argv[1])
+        hcf.init(sys.argv[1], connect_constraint_force_logger_ports=connect_constraint_force_logger_ports)
         hcf.startABSTIMP()
     else :
-        hcf.init()
+        hcf.init(connect_constraint_force_logger_ports=connect_constraint_force_logger_ports)

--- a/hrpsys_choreonoid_tutorials/scripts/jaxon_red_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/jaxon_red_setup.py
@@ -53,11 +53,12 @@ class JAXON_RED_HrpsysConfigurator(ChoreonoidHrpsysConfiguratorOrg):
 
 if __name__ == '__main__':
     hcf = JAXON_RED_HrpsysConfigurator("JAXON_RED")
+    [sys.argv, connect_constraint_force_logger_ports] = hcf.parse_arg_for_connect_ports(sys.argv)
     if len(sys.argv) > 2 :
-        hcf.init(sys.argv[1], sys.argv[2])
+        hcf.init(sys.argv[1], sys.argv[2], connect_constraint_force_logger_ports=connect_constraint_force_logger_ports)
         hcf.startABSTIMP()
     elif len(sys.argv) > 1 :
-        hcf.init(sys.argv[1])
+        hcf.init(sys.argv[1], connect_constraint_force_logger_ports=connect_constraint_force_logger_ports)
         hcf.startABSTIMP()
     else :
-        hcf.init()
+        hcf.init(connect_constraint_force_logger_ports=connect_constraint_force_logger_ports)

--- a/hrpsys_choreonoid_tutorials/src/hrpsys_choreonoid_tutorials/choreonoid_hrpsys_config.py
+++ b/hrpsys_choreonoid_tutorials/src/hrpsys_choreonoid_tutorials/choreonoid_hrpsys_config.py
@@ -33,6 +33,24 @@ class ChoreonoidHrpsysConfiguratorOrg(URATAHrpsysConfigurator):
         ##self.connectLoggerPort(self.abc, 'rhsensor')
         ##self.connectLoggerPort(self.abc, 'lhsensor')
 
+    def connectConstraintForceLoggerPorts(self):
+        for pn in filter (lambda x : re.match("F_", x), self.rh.ports.keys()):
+            self.connectLoggerPort(self.rh, pn)
+
+    def init (self, robotname="Robot", url="", connect_constraint_force_logger_ports = False):
+        URATAHrpsysConfigurator.init(self, robotname, url)
+        if connect_constraint_force_logger_ports:
+            self.connectConstraintForceLoggerPorts()
+
+    def parse_arg_for_connect_ports (self, arg_list):
+        # Check flag for connect ports
+        # Return arg list without connect port flag and connect port flag
+        if "--connect-constraint-force-logger-ports" in arg_list:
+            tmpidx = arg_list.index("--connect-constraint-force-logger-ports")
+            return [arg_list[:tmpidx]+arg_list[tmpidx+1:],True]
+        else:
+            return [arg_list, False]
+
 class ChoreonoidHrpsysConfigurator(ChoreonoidHrpsysConfiguratorOrg):
     def waitForRobotHardware(self, robotname="Robot"):
         '''!@brief


### PR DESCRIPTION
Enable to connect setuplogger for CONSTRAINT_FORCE.

Default = not logging CONSTARINT_FORCE.
```
rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch 
```
If the following argument is true, log CONSTRAINT_FORCE:
```
rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS:=true
```