### PR TITLE
Use LANG environment on the original terminal to display choreonoid both in English and Japanese.

### DIFF
--- a/hrpsys_choreonoid/launch/choreonoid.launch
+++ b/hrpsys_choreonoid/launch/choreonoid.launch
@@ -17,7 +17,7 @@
   <arg name="nameserver" default="localhost" />
   <arg name="corbaport"  default="2809" />
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
-  <env name="LANG" value="C" />
+  <env name="LANG" value="$(env LANG)" />
   <env name="ORBgiopMaxMsgSize" value="2147483648" />
   <arg if="$(arg START_SIMULATOR)"
        name="start_sim" value="--start-simulation" />


### PR DESCRIPTION
Use LANG environment on the original terminal to display choreonoid both in English and Japanese.
https://github.com/start-jsk/rtmros_choreonoid/issues/172