### PR TITLE
kill choreonoid process, if exists

### DIFF
--- a/hrpsys_choreonoid/launch/run_choreonoid.sh
+++ b/hrpsys_choreonoid/launch/run_choreonoid.sh
@@ -3,6 +3,19 @@
 ### choose choreonoid binary
 choreonoid_exe='choreonoid'
 
+if [ "$(pgrep -x ${choreonoid_exe} | wc -l)" != 0 ]; then
+    pkill -9 ${choreonoid_exe}
+    echo "****************************************************" 1>&2
+    echo "*                                                  *" 1>&2
+    echo "*                                                  *" 1>&2
+    echo "*   Old choreonoid process was found.              *" 1>&2
+    echo "*   Process has been killed, please start again.   *" 1>&2
+    echo "*                                                  *" 1>&2
+    echo "*                                                  *" 1>&2
+    echo "****************************************************" 1>&2
+    exit 1
+fi
+
 cnoid_proj=""
 if [ "$(echo $1 | grep \.cnoid$ | wc -l)" == 1 ]; then
     cnoid_proj=$1


### PR DESCRIPTION
choreonoidのプロセスが残っている場合は、killして抜けるようにしました。
抜けるようにしてあるのは、残っていたchoreonoidが現にあげているlaunchの
他のrtcなどに影響を与えている可能性があるかもしれないと思ったからです。

その場合、落ち着いてもう一度上げ直しましょう