### PR TITLE
Add sample for using hrpsys_config.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,31 @@ wstool update rtm-ros-robotics/rtmros_choreonoid
 
 ---
 
+## **Tips**
+
+### Use middle button with thinkpad keyborad
+
+Write functions below on .bashrc
+~~~
+function choreonoidinput () {
+xinput set-prop "TPPS/2 IBM TrackPoint" "Evdev Wheel Emulation" 0
+xinput set-prop "TPPS/2 IBM TrackPoint" "Evdev Wheel Emulation Button" 3
+xinput set-prop "TPPS/2 IBM TrackPoint" "Evdev Wheel Emulation" 1
+}
+
+function defaultinput () {
+xinput set-prop "TPPS/2 IBM TrackPoint" "Evdev Wheel Emulation" 0
+xinput set-prop "TPPS/2 IBM TrackPoint" "Evdev Wheel Emulation Button" 2
+xinput set-prop "TPPS/2 IBM TrackPoint" "Evdev Wheel Emulation" 1
+}
+~~~
+
+Type 'choreonoidinput' for changing role of buttons. Then middle button can work to translate views and right button can work to zoom views.
+
+For returning to default input, type 'defaultinput' in any terminals.
+
+---
+
 ## **install choreonoid from source**
 ### compile choreonoid
 ~~~

--- a/hrpsys_choreonoid/scripts/hrpsys_config_sample.py
+++ b/hrpsys_choreonoid/scripts/hrpsys_config_sample.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+###
+### Please stop nameserver 'sudo service omniorb4-nameserver stop'
+###
+
+from hrpsys.hrpsys_config import *
+import OpenHRP
+
+### settings
+nameservicehost = 'localhost'
+nameserviceport = 15005
+robotname = 'JAXON_RED(Robot)0' ## name of BodyRTC
+###
+
+import sys
+
+setattr(sys, 'argv', [''])
+
+rtm.nshost = nameservicehost
+rtm.nsport = nameserviceport
+
+hcf = HrpsysConfigurator()
+hcf.getRTCList = hcf.getRTCListUnstable
+
+hcf.waitForRTCManager(nameservicehost)
+hcf.waitForRobotHardware(robotname)
+hcf.findComps(max_timeout_count=0, verbose=False) ## search all components from getRTCList
+##
+## [hcf.abc, hcf.abc_svc, hcf.abc_version] = hcf.findComp('AutoBalancer', 'abc') ## or single component search
+
+### debug message
+rtc = hcf.getRTCInstanceList(verbose=False)
+print('\033[33;1mStarting hrpsys python interface for %s\033[0m'%(rtc[0].name()))
+print('\033[32;1m Installed rtc are ...\033[0m'),
+for r in rtc[1:]:
+    print('\033[32;1m %s \033[0m'%(r.name())),
+print('\033[32;1m\033[0m')
+print("\033[32;1m Use 'hcf' instance to access to the hrpsys controller\033[0m")
+
+### white code here
+
+#if hcf.abc_svc:
+#    hcf.abc_svc.goPos(2, 0, 0)

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_vision_connect.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_vision_connect.launch
@@ -1,6 +1,6 @@
 <launch>
   <arg name="SIMULATOR_NAME" default="JAXON_RED(Robot)0" />
-  <arg name="OUTPUT" default="screen"/>
+  <arg name="OUTPUT" default="log"/>
   <arg name="nameserver" default="localhost" />
   <arg name="corbaport" default="15005" />
   <arg name="periodic_rate" default="200" />


### PR DESCRIPTION
hrpsys_config.pyをchoreonoidのpythonコンソール内で使うサンプルを追加しました。

https://github.com/fkanehiro/hrpsys-base/pull/1083 hrpsysをこのPR以降にしてください。
また、PRがちょっと不完全でして、デフォルトのネームサーバーを止めてください
~~~
sudo service omniorb4-nameserver stop
~~~