### PR TITLE
add USE_VISION argument

### DIFF
--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_FLAT.cnoid.in
@@ -355,7 +355,7 @@ Body:
       - 
         bodyItem: 2
         showCenterOfMass: false
-        showPpcom: false
+        showPpcom: true
         showZmp: false
       - 
         bodyItem: 3

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
@@ -8,6 +8,7 @@
   <arg name="NOSIM" default="false" />
   <arg name="REALTIME" default="true" />
   <arg name="RUN_RVIZ" default="true" />
+  <arg name="USE_VISION" default="true" />
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
 
@@ -76,9 +77,12 @@
   <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server" />
 
   <!-- vision setting -->
-  <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_red_vision_connect.launch" >
-    <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
-  </include>
+  <group if="$(arg USE_VISION)">
+    <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_red_vision_connect.launch" >
+      <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
+    </include>
+  </group>
+
 
   <!--
   <arg name="launch_multisense_local" default="false" />


### PR DESCRIPTION
実時間で回らない環境(`rostopic hz /joint_states -w 100`のaverage rateが100より大きい)
のために`rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch USE_VISION:=False`でVISIONを使わなくなる設定を追加してみました．
デフォルトで`USE_VISION:=true`なので今までの使い方に影響はありません
`USE_VISION:=False`で僕はaverage rate:128→102くらいになりました．
.cnoid中のGLVisionSimulatorアイテムはあってもなくても速度は変わらなかったので新しく.cnoid追加したりはしていません．

