### PR TITLE
allow multi Choreonoid simulation

### DIFF
--- a/hrpsys_choreonoid/launch/ros_bridge_choreonoid.launch
+++ b/hrpsys_choreonoid/launch/ros_bridge_choreonoid.launch
@@ -6,6 +6,7 @@
   <arg name="RUN_RVIZ" default="false" />
 
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="15006" />
 
   <arg name="USE_WALKING"             default="true"  />
   <arg name="USE_COLLISIONCHECK"      default="false" />
@@ -28,6 +29,7 @@
     <arg name="COLLADA_FILE" value="$(arg COLLADA_FILE)" />
     <arg name="CONF_FILE"    value="$(arg CONF_FILE)" />
     <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- unstable RTC -->
     <arg name="USE_WALKING"               value="$(arg USE_WALKING)" />
     <arg name="USE_COLLISIONCHECK"        value="$(arg USE_COLLISIONCHECK)" />

--- a/hrpsys_choreonoid/launch/run_choreonoid.sh
+++ b/hrpsys_choreonoid/launch/run_choreonoid.sh
@@ -3,18 +3,18 @@
 ### choose choreonoid binary
 choreonoid_exe='choreonoid'
 
-if [ "$(pgrep -x ${choreonoid_exe} | wc -l)" != 0 ]; then
-    pkill -9 ${choreonoid_exe}
-    echo "****************************************************" 1>&2
-    echo "*                                                  *" 1>&2
-    echo "*                                                  *" 1>&2
-    echo "*   Old choreonoid process was found.              *" 1>&2
-    echo "*   Process has been killed, please start again.   *" 1>&2
-    echo "*                                                  *" 1>&2
-    echo "*                                                  *" 1>&2
-    echo "****************************************************" 1>&2
-    exit 1
-fi
+# if [ "$(pgrep -x ${choreonoid_exe} | wc -l)" != 0 ]; then
+#     pkill -9 ${choreonoid_exe}
+#     echo "****************************************************" 1>&2
+#     echo "*                                                  *" 1>&2
+#     echo "*                                                  *" 1>&2
+#     echo "*   Old choreonoid process was found.              *" 1>&2
+#     echo "*   Process has been killed, please start again.   *" 1>&2
+#     echo "*                                                  *" 1>&2
+#     echo "*                                                  *" 1>&2
+#     echo "****************************************************" 1>&2
+#     exit 1
+# fi
 
 cnoid_proj=""
 if [ "$(echo $1 | grep \.cnoid$ | wc -l)" == 1 ]; then

--- a/hrpsys_choreonoid/launch/startup_choreonoid.launch
+++ b/hrpsys_choreonoid/launch/startup_choreonoid.launch
@@ -12,6 +12,7 @@
   <arg name="REALTIME" default="true" />
   <arg name="OUTPUT" default="log"/>
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="15006" />
   <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="false"/>
 
   <arg name="RobotHardware_conf" default="$(arg CONF_FILE)"/>
@@ -36,6 +37,7 @@
     <arg name="KILL_SERVERS" value="$(arg KILL_SERVERS)" />
     <arg name="REALTIME" value="$(arg REALTIME)" />
     <arg name="corbaport" value="$(arg corbaport)" />
+    <arg name="managerport" value="$(arg managerport)" />
     <arg name="openrtm_openhrp_server_start" value="true"/>
     <arg name="RESPAWN_MODELLOADER" value="false" />
     <arg name="GUI" default="$(arg GUI)" />

--- a/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
@@ -5,9 +5,12 @@
   <arg name="KILL_SERVERS" default="false" />
   <arg name="NOSIM" default="false" />
   <arg name="REALTIME" default="true" />
+  <arg name="USE_ROS" default="true" />
   <arg name="RUN_RVIZ" default="true" />
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
+  <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="15006" />
   <!-- robot dependant settings -->
   <arg if="$(arg USE_ROBOTHARDWARE)"
        name="taskname" value="RH_$(arg TASK)" />
@@ -33,6 +36,8 @@
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     <arg name="PROJECT_FILE"   value="$(arg PROJECT_FILE)" />
@@ -48,33 +53,21 @@
     <arg name="hrpsys_precreate_rtc" value="$(arg hrpsys_precreate_rtc)" />
     <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="$(arg CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS)"/>
   </include>
-  <!-- ros_bridge -->
-  <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
-  <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
-    <!-- robot dependant settings -->
-    <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
-    <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
-    <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>
-    <arg name="CONF_FILE"      value="$(arg CONF_FILE)" />
-  </include>
+  <group if="$(arg USE_ROS)">
+    <!-- ros_bridge -->
+    <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
+    <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
+      <!-- robot dependant settings -->
+      <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
+      <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
+      <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>
+      <arg name="CONF_FILE"      value="$(arg CONF_FILE)" />
+    </include>
+    <!--                     -->
+    <!-- additional settings -->
+    <!--                     -->
+    <!-- additional ros_bridge -->
+    <include file="$(find jsk_footstep_controller)/launch/hrp2jsk_footcoords.launch" />
+  </group>
 
-  <!--                     -->
-  <!-- additional settings -->
-  <!--                     -->
-  <!-- additional ros_bridge -->
-  <include file="$(find jsk_footstep_controller)/launch/hrp2jsk_footcoords.launch" />
-
-  <!-- vision setting -->
-<!--  <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_red_vision_connect.launch" >-->
-<!--    <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />-->
-<!--  </include>-->
-
-  <!--
-  <arg name="launch_multisense_local" default="false" />
-  <arg name="launch_multisense_remote" default="false" />
-  <include if="$(arg launch_multisense_local)"
-           file="$(find jaxon_ros_bridge)/launch/jaxon_multisense_local.launch" />
-  <include if="$(arg launch_multisense_remote)"
-           file="$(find hrpsys_ros_bridge_jvrc)/launch/jaxon_jvrc_multisense.launch" />
-  -->
 </launch>

--- a/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
@@ -57,6 +57,8 @@
     <!-- ros_bridge -->
     <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
     <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
+      <arg name="corbaport" default="$(arg corbaport)" />
+      <arg name="managerport" default="$(arg managerport)" />
       <!-- robot dependant settings -->
       <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
       <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_blue_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_blue_choreonoid.launch
@@ -8,12 +8,15 @@
   <arg name="KILL_SERVERS" default="false" />
   <arg name="NOSIM" default="false" />
   <arg name="REALTIME" default="true" />
+  <arg name="USE_ROS" default="true" />
   <arg name="RUN_RVIZ" default="true" />
   <!-- <arg name="USE_VISION" default="true" /> -->
   <arg name="USE_VISION" default="false" />
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
   <arg name="LAUNCH_FOOTCOORDS" default="true" />
+  <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="15006" />
 
   <!-- robot dependant settings -->
   <arg if="$(arg USE_ROBOTHARDWARE)"
@@ -47,6 +50,8 @@
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     <arg name="PROJECT_FILE"   value="$(arg PROJECT_FILE)" />
@@ -62,39 +67,42 @@
     <arg name="hrpsys_precreate_rtc" value="$(arg hrpsys_precreate_rtc)" />
     <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="$(arg CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS)"/>
   </include>
-  <!-- ros_bridge -->
-  <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
-  <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
-    <!-- robot dependant settings -->
-    <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
-    <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
-    <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>
-    <arg name="CONF_FILE"      value="$(arg CONF_FILE)" />
-  </include>
 
-  <!--                     -->
-  <!-- additional settings -->
-  <!--                     -->
-  <!-- additional ros_bridge -->
-  <include file="$(find jsk_footstep_controller)/launch/hrp2jsk_footcoords.launch"
-           if="$(arg LAUNCH_FOOTCOORDS)" />
-  <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server"
-        if="$(arg LAUNCH_FOOTCOORDS)" />
-
-  <!-- vision setting -->
-  <group if="$(arg USE_VISION)">
-    <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_blue_vision_connect.launch" >
-      <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
+  <group if="$(arg USE_ROS)">
+    <!-- ros_bridge -->
+    <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
+    <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
+      <!-- robot dependant settings -->
+      <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
+      <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
+      <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>
+      <arg name="CONF_FILE"      value="$(arg CONF_FILE)" />
     </include>
+
+    <!--                     -->
+    <!-- additional settings -->
+    <!--                     -->
+    <!-- additional ros_bridge -->
+    <include file="$(find jsk_footstep_controller)/launch/hrp2jsk_footcoords.launch"
+             if="$(arg LAUNCH_FOOTCOORDS)" />
+    <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server"
+          if="$(arg LAUNCH_FOOTCOORDS)" />
+
+    <!-- vision setting -->
+    <group if="$(arg USE_VISION)">
+      <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_blue_vision_connect.launch" >
+        <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
+      </include>
+    </group>
+
+
+    <!--
+        <arg name="launch_multisense_local" default="false" />
+        <arg name="launch_multisense_remote" default="false" />
+        <include if="$(arg launch_multisense_local)"
+        file="$(find jaxon_ros_bridge)/launch/jaxon_multisense_local.launch" />
+        <include if="$(arg launch_multisense_remote)"
+        file="$(find hrpsys_ros_bridge_jvrc)/launch/jaxon_jvrc_multisense.launch" />
+    -->
   </group>
-
-
-  <!--
-  <arg name="launch_multisense_local" default="false" />
-  <arg name="launch_multisense_remote" default="false" />
-  <include if="$(arg launch_multisense_local)"
-           file="$(find jaxon_ros_bridge)/launch/jaxon_multisense_local.launch" />
-  <include if="$(arg launch_multisense_remote)"
-           file="$(find hrpsys_ros_bridge_jvrc)/launch/jaxon_jvrc_multisense.launch" />
-  -->
 </launch>

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_blue_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_blue_choreonoid.launch
@@ -72,6 +72,8 @@
     <!-- ros_bridge -->
     <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
     <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
+      <arg name="corbaport" default="$(arg corbaport)" />
+      <arg name="managerport" default="$(arg managerport)" />
       <!-- robot dependant settings -->
       <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
       <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
@@ -91,6 +93,8 @@
     <!-- vision setting -->
     <group if="$(arg USE_VISION)">
       <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_blue_vision_connect.launch" >
+        <arg name="corbaport" default="$(arg corbaport)" />
+        <arg name="managerport" default="$(arg managerport)" />
         <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
       </include>
     </group>

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
@@ -77,6 +77,8 @@
     <!-- ros_bridge -->
     <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
     <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
+      <arg name="corbaport" default="$(arg corbaport)" />
+      <arg name="managerport" default="$(arg managerport)" />
       <!-- robot dependant settings -->
       <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
       <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
@@ -96,6 +98,8 @@
     <!-- vision setting -->
     <group if="$(arg USE_VISION)">
       <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_red_vision_connect.launch" >
+        <arg name="corbaport" default="$(arg corbaport)" />
+        <arg name="managerport" default="$(arg managerport)" />
         <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
       </include>
     </group>

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
@@ -8,11 +8,14 @@
   <arg name="KILL_SERVERS" default="false" />
   <arg name="NOSIM" default="false" />
   <arg name="REALTIME" default="true" />
+  <arg name="USE_ROS" default="true" />
   <arg name="RUN_RVIZ" default="true" />
   <arg name="USE_VISION" default="true" />
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
   <arg name="LAUNCH_FOOTCOORDS" default="true" />
+  <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="15006" />
 
   <!-- robot dependant settings -->
   <arg if="$(arg USE_ROBOTHARDWARE)"
@@ -51,6 +54,8 @@
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     <arg name="PROJECT_FILE"   value="$(arg PROJECT_FILE)" />
@@ -66,39 +71,45 @@
     <arg name="hrpsys_precreate_rtc" value="$(arg hrpsys_precreate_rtc)" />
     <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="$(arg CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS)"/>
   </include>
-  <!-- ros_bridge -->
-  <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
-  <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
-    <!-- robot dependant settings -->
-    <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
-    <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
-    <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>
-    <arg name="CONF_FILE"      value="$(arg CONF_FILE)" />
-  </include>
 
-  <!--                     -->
-  <!-- additional settings -->
-  <!--                     -->
-  <!-- additional ros_bridge -->
-  <include file="$(find jsk_footstep_controller)/launch/hrp2jsk_footcoords.launch"
-           if="$(arg LAUNCH_FOOTCOORDS)" />
-  <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server"
-        if="$(arg LAUNCH_FOOTCOORDS)" />
+  <group if="$(arg USE_ROS)">
 
-  <!-- vision setting -->
-  <group if="$(arg USE_VISION)">
-    <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_red_vision_connect.launch" >
-      <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
+    <!-- ros_bridge -->
+    <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
+    <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
+      <!-- robot dependant settings -->
+      <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
+      <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
+      <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>
+      <arg name="CONF_FILE"      value="$(arg CONF_FILE)" />
     </include>
+
+    <!--                     -->
+    <!-- additional settings -->
+    <!--                     -->
+    <!-- additional ros_bridge -->
+    <include file="$(find jsk_footstep_controller)/launch/hrp2jsk_footcoords.launch"
+             if="$(arg LAUNCH_FOOTCOORDS)" />
+    <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server"
+          if="$(arg LAUNCH_FOOTCOORDS)" />
+
+    <!-- vision setting -->
+    <group if="$(arg USE_VISION)">
+      <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_red_vision_connect.launch" >
+        <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
+      </include>
+    </group>
+
+
+    <!--
+        <arg name="launch_multisense_local" default="false" />
+        <arg name="launch_multisense_remote" default="false" />
+        <include if="$(arg launch_multisense_local)"
+        file="$(find jaxon_ros_bridge)/launch/jaxon_multisense_local.launch" />
+        <include if="$(arg launch_multisense_remote)"
+        file="$(find hrpsys_ros_bridge_jvrc)/launch/jaxon_jvrc_multisense.launch" />
+    -->
+  
   </group>
 
-
-  <!--
-  <arg name="launch_multisense_local" default="false" />
-  <arg name="launch_multisense_remote" default="false" />
-  <include if="$(arg launch_multisense_local)"
-           file="$(find jaxon_ros_bridge)/launch/jaxon_multisense_local.launch" />
-  <include if="$(arg launch_multisense_remote)"
-           file="$(find hrpsys_ros_bridge_jvrc)/launch/jaxon_jvrc_multisense.launch" />
-  -->
 </launch>

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_vision_connect.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_vision_connect.launch
@@ -3,9 +3,10 @@
   <arg name="OUTPUT" default="log"/>
   <arg name="nameserver" default="localhost" />
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="15006" />
   <arg name="periodic_rate" default="200" />
 
-  <arg name="openrtm_args" default='-o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
+  <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
 
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
   <env name="LANG" value="C" />


### PR DESCRIPTION
```
rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch corbaport:=35005 managerport:=35006 USE_ROS:=false
rtmlaunch hrpsys_choreonoid_tutorials jaxon_blue_choreonoid.launch corbaport:=45005 managerport:=45006 USE_ROS:=false
rtmlaunch hrpsys_choreonoid_tutorials chidori_choreonoid.launch corbaport:=55005 managerport:=55006 USE_ROS:=false
hrpsyspy --port 35005 --robot "JAXON_RED(Robot)0"
hrpsyspy --port 45005 --robot "JAXON_BLUE(Robot)0"
hrpsyspy --port 55005 --robot "CHIDORI(Robot)0"
```
で同時起動して各々のロボットにgoPosが送れることが確認できたので一旦送ります．
起動時に前回の残っているchoreonoidプロセスをkillする部分はコメントアウトしました(多重起動できないので)．
構成などに希望があればコメントお願いします．

https://github.com/start-jsk/rtmros_common/pull/1054
https://github.com/fkanehiro/hrpsys-base/pull/1253
が必要