### PR TITLE
[ros_bridge_choreonoid.launch and some launch files] let USE_ROBOTHAR…

### DIFF
--- a/hrpsys_choreonoid/launch/ros_bridge_choreonoid.launch
+++ b/hrpsys_choreonoid/launch/ros_bridge_choreonoid.launch
@@ -7,6 +7,7 @@
 
   <arg name="corbaport" default="15005" />
 
+  <arg name="USE_ROBOTHARDWARE"       default="true" />
   <arg name="USE_WALKING"             default="true"  />
   <arg name="USE_COLLISIONCHECK"      default="false" />
   <arg name="USE_IMPEDANCECONTROLLER" default="true"  />
@@ -28,6 +29,7 @@
     <arg name="COLLADA_FILE" value="$(arg COLLADA_FILE)" />
     <arg name="CONF_FILE"    value="$(arg CONF_FILE)" />
     <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="USE_ROBOTHARDWARE" default="$(arg USE_ROBOTHARDWARE)" />
     <!-- unstable RTC -->
     <arg name="USE_WALKING"               value="$(arg USE_WALKING)" />
     <arg name="USE_COLLISIONCHECK"        value="$(arg USE_COLLISIONCHECK)" />

--- a/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
@@ -52,6 +52,7 @@
   <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
   <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
     <!-- robot dependant settings -->
+    <arg name="USE_ROBOTHARDWARE" value="$(arg USE_ROBOTHARDWARE)" />
     <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
     <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
     <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_blue_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_blue_choreonoid.launch
@@ -66,6 +66,7 @@
   <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
   <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
     <!-- robot dependant settings -->
+    <arg name="USE_ROBOTHARDWARE" value="$(arg USE_ROBOTHARDWARE)" />
     <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
     <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
     <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
@@ -70,6 +70,7 @@
   <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
   <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
     <!-- robot dependant settings -->
+    <arg name="USE_ROBOTHARDWARE" value="$(arg USE_ROBOTHARDWARE)" />
     <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
     <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
     <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>


### PR DESCRIPTION
…DWARE argument be passed to hrpsys_ros_bridge.launch

jaxon_red_choreonoid.launch等の個別ロボットのlaunchファイルで引数USE_ROBOTHARDWAREを変更してもhrpsys_ros_bridge.launchにその引数が渡らず、RobotHardwareServiceが立ち上がらないなどの問題があったので修正しました。