### PR TITLE
add yaml file and read it from JAXONCustomizer

### DIFF
--- a/hrpsys_choreonoid/CMakeLists.txt
+++ b/hrpsys_choreonoid/CMakeLists.txt
@@ -22,6 +22,7 @@ pkg_check_modules(hrpsys hrpsys-base REQUIRED)
 
 pkg_check_modules(cnoid-plugin choreonoid-body-plugin)
 find_package(Boost REQUIRED system filesystem)
+pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
 ##catkin_python_setup()
 
 catkin_package(
@@ -42,7 +43,7 @@ if(${cnoid-plugin_FOUND})
   include_directories(${catkin_INCLUDE_DIRS} ${openrtm_aist_INCLUDE_DIRS} ${cnoid-plugin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${hrpsys_INCLUDE_DIRS})
   link_directories(${catkin_LIBRARY_DIRS} ${openrtm_aist_LIBRARY_DIRS} ${cnoid-plugin_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS} ${hrpsys_LIBRARY_DIRS})
   add_library(JAXONCustomizer src/JAXONCustomizer.cpp)
-  target_link_libraries(JAXONCustomizer ${cnoid-plugin_LIBRARIES} yaml-cpp)
+  target_link_libraries(JAXONCustomizer ${cnoid-plugin_LIBRARIES} ${YAML_CPP_LIBRARIES})
   set_target_properties(JAXONCustomizer PROPERTIES COMPILE_FLAG "-fPIC" PREFIX "" SUFFIX ".so" LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
 ##
   include_directories(${catkin_INCLUDE_DIRS} ${openrtm_aist_INCLUDE_DIRS} ${cnoid-plugin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${hrpsys_INCLUDE_DIRS})

--- a/hrpsys_choreonoid/CMakeLists.txt
+++ b/hrpsys_choreonoid/CMakeLists.txt
@@ -42,7 +42,7 @@ if(${cnoid-plugin_FOUND})
   include_directories(${catkin_INCLUDE_DIRS} ${openrtm_aist_INCLUDE_DIRS} ${cnoid-plugin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${hrpsys_INCLUDE_DIRS})
   link_directories(${catkin_LIBRARY_DIRS} ${openrtm_aist_LIBRARY_DIRS} ${cnoid-plugin_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS} ${hrpsys_LIBRARY_DIRS})
   add_library(JAXONCustomizer src/JAXONCustomizer.cpp)
-  target_link_libraries(JAXONCustomizer ${cnoid-plugin_LIBRARIES})
+  target_link_libraries(JAXONCustomizer ${cnoid-plugin_LIBRARIES} yaml-cpp)
   set_target_properties(JAXONCustomizer PROPERTIES COMPILE_FLAG "-fPIC" PREFIX "" SUFFIX ".so" LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
 ##
   include_directories(${catkin_INCLUDE_DIRS} ${openrtm_aist_INCLUDE_DIRS} ${cnoid-plugin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${hrpsys_INCLUDE_DIRS})

--- a/hrpsys_choreonoid/config/CHIDORI.conf
+++ b/hrpsys_choreonoid/config/CHIDORI.conf
@@ -1,0 +1,9 @@
+springT: 1.1e6
+dampingT: 1.1e3
+springR: 2.5e3
+dampingR: 2.5
+
+TILT_UPPER_BOUND: 1.35
+TILT_POSITIVE_SPEED: 1.0
+TILT_LOWER_BOUND: -0.7
+TILT_NEGATIVE_SPEED: -1.0

--- a/hrpsys_choreonoid/config/CHIDORI.conf
+++ b/hrpsys_choreonoid/config/CHIDORI.conf
@@ -1,9 +1,0 @@
-springT: 1.1e6
-dampingT: 1.1e3
-springR: 2.5e3
-dampingR: 2.5
-
-TILT_UPPER_BOUND: 1.35
-TILT_POSITIVE_SPEED: 1.0
-TILT_LOWER_BOUND: -0.7
-TILT_NEGATIVE_SPEED: -1.0

--- a/hrpsys_choreonoid/config/CHIDORICustomizer.yaml
+++ b/hrpsys_choreonoid/config/CHIDORICustomizer.yaml
@@ -1,0 +1,11 @@
+bush:
+  springT: 1.1e6
+  dampingT: 1.1e3
+  springR: 2.5e3
+  dampingR: 2.5
+
+tilt_laser:
+  TILT_UPPER_BOUND: 1.35
+  TILT_POSITIVE_SPEED: 1.0
+  TILT_LOWER_BOUND: -0.7
+  TILT_NEGATIVE_SPEED: -1.0

--- a/hrpsys_choreonoid/package.xml
+++ b/hrpsys_choreonoid/package.xml
@@ -18,14 +18,14 @@
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>openrtm_aist</build_depend>
-  <build_depend>common_rosdeps</build_depend>
+  <build_depend>yaml-cpp</build_depend>
 
   <run_depend>hrpsys</run_depend>
   <run_depend>openhrp3</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>openrtm_aist</run_depend>
-  <run_depend>common_rosdeps</run_depend>
+  <run_depend>yaml-cpp</run_depend>
 
   <export>
   </export>

--- a/hrpsys_choreonoid/package.xml
+++ b/hrpsys_choreonoid/package.xml
@@ -18,12 +18,14 @@
   <build_depend>roscpp</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>openrtm_aist</build_depend>
+  <build_depend>common_rosdeps</build_depend>
 
   <run_depend>hrpsys</run_depend>
   <run_depend>openhrp3</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>openrtm_aist</run_depend>
+  <run_depend>common_rosdeps</run_depend>
 
   <export>
   </export>

--- a/hrpsys_choreonoid/src/JAXONCustomizer.cpp
+++ b/hrpsys_choreonoid/src/JAXONCustomizer.cpp
@@ -2,8 +2,10 @@
 
 #include <cmath>
 #include <cstring>
+#include <fstream>
 #include <boost/function.hpp>
 #include <boost/bind.hpp>
+#include <yaml-cpp/yaml.h>
 
 #define CNOID_BODY_CUSTOMIZER
 #ifdef CNOID_BODY_CUSTOMIZER
@@ -16,8 +18,8 @@
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 #define DLL_EXPORT __declspec(dllexport)
-#else 
-#define DLL_EXPORT 
+#else
+#define DLL_EXPORT
 #endif /* Windows */
 
 #if defined(HRPMODEL_VERSION_MAJOR) && defined(HRPMODEL_VERSION_MINOR)
@@ -66,6 +68,11 @@ struct JAXONCustomizer
   double dampingT;
   double springR;
   double dampingR;
+
+  double tilt_upper_bound;
+  double tilt_lower_bound;
+  double tilt_positive_speed;
+  double tilt_negative_speed;
 
   //* *//
   bool hasMultisenseJoint;
@@ -165,6 +172,30 @@ static BodyCustomizerHandle create(BodyHandle bodyHandle, const char* modelName)
   customizer->springR  = 2.5e3; // Nm / rad
   customizer->dampingR = 2.5;   // Nm / (rad/s)
 
+  customizer->tilt_upper_bound = 1.35; // rad
+  customizer->tilt_lower_bound = -0.7; // rad
+  customizer->tilt_positive_speed = 1.0; // rad/s
+  customizer->tilt_negative_speed = -1.0; // rad/s
+
+  char* config_file_path = getenv("CUSTOMIZER_CONF_FILE");
+  if (config_file_path) {
+    ifstream ifs(config_file_path);
+    if (ifs.is_open()) {
+      std::cerr << "[JAXONCustomizer] Config file is: " << config_file_path << std::endl;
+      YAML::Node sensors_param = YAML::LoadFile(config_file_path);
+      customizer->springT  = sensors_param["springT"].as<double>();
+      customizer->dampingT = sensors_param["dampingT"].as<double>();
+      customizer->springR  = sensors_param["springR"].as<double>();
+      customizer->dampingR = sensors_param["dampingR"].as<double>();
+      customizer->tilt_upper_bound = sensors_param["TILT_UPPER_BOUND"].as<double>();
+      customizer->tilt_positive_speed = sensors_param["TILT_POSITIVE_SPEED"].as<double>();
+      customizer->tilt_lower_bound = sensors_param["TILT_LOWER_BOUND"].as<double>();
+      customizer->tilt_negative_speed = sensors_param["TILT_NEGATIVE_SPEED"].as<double>();
+    } else {
+      std::cerr << "[JAXONCustomizer] " << config_file_path << " is not found" << std::endl;
+    }
+  }
+
   getVirtualbushJoints(customizer, bodyHandle);
 
   return static_cast<BodyCustomizerHandle>(customizer);
@@ -208,29 +239,24 @@ static void setVirtualJointForces(BodyCustomizerHandle customizerHandle)
     dq_old = dq;
   }
 
-#define TILT_UPPER_BOUND  0.7
-#define TILT_POSITIVE_SPEED 1.0
-#define TILT_LOWER_BOUND -0.7
-#define TILT_NEGATIVE_SPEED -1.0
   if(customizer->hasTiltLaserJoint) {
     JointValSet& trans = customizer->tilt_laser_joint;
     static double dq_old = 0.0;
     static bool move_positive = true;
     double  q = *(trans.valuePtr);
-    if (q > TILT_UPPER_BOUND) {
+    if (q > customizer->tilt_upper_bound) {
       move_positive = false;
-    } else if (q < TILT_LOWER_BOUND) {
+    } else if (q < customizer->tilt_lower_bound) {
       move_positive = true;
     }
 
     double dq = *(trans.velocityPtr);
     double tq;
+    double ddq = (dq - dq_old) / 0.001; // dt = 0.001
     if (move_positive) {
-      double ddq = (dq - dq_old)/0.001; // dt = 0.001
-      tq = -(dq - TILT_POSITIVE_SPEED) * 100 - 0.2 * ddq;
+      tq = -(dq - customizer->tilt_positive_speed) * 100 - 0.2 * ddq;
     } else {
-      double ddq = (dq - dq_old)/0.001; // dt = 0.001
-      tq = -(dq - TILT_NEGATIVE_SPEED) * 100 - 0.2 * ddq;
+      tq = -(dq - customizer->tilt_negative_speed) * 100 - 0.2 * ddq;
     }
     double tlimit = 200;
     *(trans.torqueForcePtr) = std::max(std::min(tq, tlimit), -tlimit);

--- a/hrpsys_choreonoid/src/JAXONCustomizer.cpp
+++ b/hrpsys_choreonoid/src/JAXONCustomizer.cpp
@@ -182,15 +182,15 @@ static BodyCustomizerHandle create(BodyHandle bodyHandle, const char* modelName)
     ifstream ifs(config_file_path);
     if (ifs.is_open()) {
       std::cerr << "[JAXONCustomizer] Config file is: " << config_file_path << std::endl;
-      YAML::Node sensors_param = YAML::LoadFile(config_file_path);
-      customizer->springT  = sensors_param["springT"].as<double>();
-      customizer->dampingT = sensors_param["dampingT"].as<double>();
-      customizer->springR  = sensors_param["springR"].as<double>();
-      customizer->dampingR = sensors_param["dampingR"].as<double>();
-      customizer->tilt_upper_bound = sensors_param["TILT_UPPER_BOUND"].as<double>();
-      customizer->tilt_positive_speed = sensors_param["TILT_POSITIVE_SPEED"].as<double>();
-      customizer->tilt_lower_bound = sensors_param["TILT_LOWER_BOUND"].as<double>();
-      customizer->tilt_negative_speed = sensors_param["TILT_NEGATIVE_SPEED"].as<double>();
+      YAML::Node param = YAML::LoadFile(config_file_path);
+      customizer->springT  = param["bush"]["springT"].as<double>();
+      customizer->dampingT = param["bush"]["dampingT"].as<double>();
+      customizer->springR  = param["bush"]["springR"].as<double>();
+      customizer->dampingR = param["bush"]["dampingR"].as<double>();
+      customizer->tilt_upper_bound    = param["tilt_laser"]["TILT_UPPER_BOUND"].as<double>();
+      customizer->tilt_positive_speed = param["tilt_laser"]["TILT_POSITIVE_SPEED"].as<double>();
+      customizer->tilt_lower_bound    = param["tilt_laser"]["TILT_LOWER_BOUND"].as<double>();
+      customizer->tilt_negative_speed = param["tilt_laser"]["TILT_NEGATIVE_SPEED"].as<double>();
     } else {
       std::cerr << "[JAXONCustomizer] " << config_file_path << " is not found" << std::endl;
     }

--- a/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
@@ -31,7 +31,7 @@
        value="$(find hrpsys_ros_bridge_tutorials)/models/CHIDORI_controller_config.yaml" />
   <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="false"/>
 
-  <env name="CUSTOMIZER_CONF_FILE" value="$(find hrpsys_choreonoid)/config/CHIDORI.conf" />
+  <env name="CUSTOMIZER_CONF_FILE" value="$(find hrpsys_choreonoid)/config/CHIDORICustomizer.yaml" />
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >

--- a/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
@@ -31,6 +31,8 @@
        value="$(find hrpsys_ros_bridge_tutorials)/models/CHIDORI_controller_config.yaml" />
   <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="false"/>
 
+  <env name="CUSTOMIZER_CONF_FILE" value="$(find hrpsys_choreonoid)/config/CHIDORI.conf" />
+
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
     <!-- robot dependant settings -->


### PR DESCRIPTION
`JAXONCustomizer.cpp`の内部で設定していた一部パラメータを，外部のyamlファイルから与えられるように変更しました．

とりあえずchidoriだけですが，
`<robot_name>_choreonoid.launch`
の内部でconfing fileのpathをenvにセットし，
`JAXONCustomizer.cpp`
でenvのpathを取得しconfig fileを読み，センサなどのパラメータを取得するようにしました．

config fileの名前は`<ROBOT_NAME>Customizer.yaml`にしてあります.