### PR TITLE
[CMakeLists.txt] Fix include directories path order

### DIFF
--- a/hrpsys_choreonoid/CMakeLists.txt
+++ b/hrpsys_choreonoid/CMakeLists.txt
@@ -15,10 +15,9 @@ else()
   message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. Please use a different C++ compiler.")
 endif()
 
-include(FindPkgConfig)
-pkg_check_modules(openhrp3 REQUIRED openhrp3.1)
-set(OPENHRP_SAMPLE_DIR ${openhrp3_PREFIX}/share/OpenHRP-3.1/sample)
+find_package(PkgConfig REQUIRED)
 pkg_check_modules(hrpsys hrpsys-base REQUIRED)
+pkg_check_modules(openrtm_aist openrtm-aist REQUIRED)
 
 pkg_check_modules(cnoid-plugin choreonoid-body-plugin)
 find_package(Boost REQUIRED system filesystem)
@@ -31,48 +30,45 @@ catkin_package(
     LIBRARIES # TODO
 )
 
+include_directories(${hrpsys_INCLUDE_DIRS} ${openrtm_aist_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS})
+link_directories(${hrpsys_LIBRARY_DIRS} ${openrtm_aist_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS} ${catkin_LIBRARY_DIRS})
 if(${cnoid-plugin_FOUND})
-  include_directories(${catkin_INCLUDE_DIRS} ${openrtm_aist_INCLUDE_DIRS} ${cnoid-plugin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${hrpsys_INCLUDE_DIRS})
-  link_directories(${catkin_LIBRARY_DIRS} ${openrtm_aist_LIBRARY_DIRS} ${cnoid-plugin_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS} ${hrpsys_LIBRARY_DIRS})
-
+  include_directories(${cnoid-plugin_INCLUDE_DIRS})
+  link_directories(${cnoid-plugin_LIBRARY_DIRS})
+  ##
   add_library(PDcontroller src/PDcontroller.cpp)
   target_link_libraries(PDcontroller ${openrtm_aist_LIBRARIES} ${cnoid-plugin_LIBRARIES} ${Boost_LIBRARIES} ${hrpsys_LIBRARIES} ${catkin_LIBRARIES})
   set_target_properties(PDcontroller PROPERTIES COMPILE_FLAG "-fPIC" PREFIX "" SUFFIX ".so" LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-###
-  include_directories(${catkin_INCLUDE_DIRS} ${openrtm_aist_INCLUDE_DIRS} ${cnoid-plugin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${hrpsys_INCLUDE_DIRS})
-  link_directories(${catkin_LIBRARY_DIRS} ${openrtm_aist_LIBRARY_DIRS} ${cnoid-plugin_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS} ${hrpsys_LIBRARY_DIRS})
+  ##
   add_library(JAXONCustomizer src/JAXONCustomizer.cpp)
   target_link_libraries(JAXONCustomizer ${cnoid-plugin_LIBRARIES})
   set_target_properties(JAXONCustomizer PROPERTIES COMPILE_FLAG "-fPIC" PREFIX "" SUFFIX ".so" LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-##
-  include_directories(${catkin_INCLUDE_DIRS} ${openrtm_aist_INCLUDE_DIRS} ${cnoid-plugin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${hrpsys_INCLUDE_DIRS})
-  link_directories(${catkin_LIBRARY_DIRS} ${openrtm_aist_LIBRARY_DIRS} ${cnoid-plugin_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS} ${hrpsys_LIBRARY_DIRS})
+  ##
   add_library(DOORCustomizer src/DOORCustomizer.cpp)
   target_link_libraries(DOORCustomizer ${cnoid-plugin_LIBRARIES})
   set_target_properties(DOORCustomizer PROPERTIES COMPILE_FLAG "-fPIC" PREFIX "" SUFFIX ".so" LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR})
-##
-  include_directories(${catkin_INCLUDE_DIRS} ${openrtm_aist_INCLUDE_DIRS} ${cnoid-plugin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS} ${hrpsys_INCLUDE_DIRS})
-  link_directories(${catkin_LIBRARY_DIRS} ${openrtm_aist_LIBRARY_DIRS} ${cnoid-plugin_LIBRARY_DIRS} ${Boost_LIBRARY_DIRS} ${hrpsys_LIBRARY_DIRS})
+  ##
   add_executable(JointStateROSBridge src/JointStateROSBridge.cpp src/JointStateROSBridgeComp.cpp)
   target_link_libraries(JointStateROSBridge ${openrtm_aist_LIBRARIES} ${cnoid-plugin_LIBRARIES} ${Boost_LIBRARIES} ${hrpsys_LIBRARIES} ${catkin_LIBRARIES})
+  ##
   add_executable(TransformROSBridge src/TransformROSBridge.cpp src/TransformROSBridgeComp.cpp)
   target_link_libraries(TransformROSBridge ${openrtm_aist_LIBRARIES} ${cnoid-plugin_LIBRARIES} ${Boost_LIBRARIES} ${hrpsys_LIBRARIES} ${catkin_LIBRARIES})
+  ##
   add_executable(ImuROSBridge src/ImuROSBridge.cpp src/ImuROSBridgeComp.cpp)
   target_link_libraries(ImuROSBridge ${openrtm_aist_LIBRARIES} ${cnoid-plugin_LIBRARIES} ${Boost_LIBRARIES} ${hrpsys_LIBRARIES} ${catkin_LIBRARIES})
 endif()
 
 ## Build only choreonoid iob
-find_package(PkgConfig)
+pkg_check_modules(openhrp3 REQUIRED openhrp3.1)
 pkg_check_modules(omniorb omniORB4 REQUIRED)
 pkg_check_modules(omnidynamic omniDynamic4 REQUIRED)
-pkg_check_modules(openrtm_aist openrtm-aist REQUIRED)
-pkg_check_modules(openhrp3 openhrp3.1 REQUIRED)
-pkg_check_modules(hrpsys hrpsys-base REQUIRED)
 ### hotfix for https://github.com/fkanehiro/hrpsys-base/pull/803
 list(GET hrpsys_INCLUDE_DIRS 0 hrpsys_first_incdir)
-list(APPEND hrpsys_INCLUDE_DIRS ${hrpsys_first_incdir}/hrpsys)
-list(APPEND hrpsys_INCLUDE_DIRS ${hrpsys_first_incdir}/hrpsys/idl)
-list(APPEND hrpsys_INCLUDE_DIRS ${hrpsys_first_incdir}/hrpsys/io)
+include_directories(BEFORE ${hrpsys_first_incdir}/hrpsys)
+include_directories(BEFORE ${hrpsys_first_incdir}/hrpsys/idl)
+include_directories(BEFORE ${hrpsys_first_incdir}/hrpsys/io)
+include_directories(${openhrp3_INCLUDE_DIRS})
+link_directories(${openhrp3_LIBRARY_DIRS})
 if(EXISTS ${hrpsys_SOURCE_DIR})
   set(ROBOTHARDWARE_SOURCE ${hrpsys_SOURCE_DIR}/src/rtc/RobotHardware)
   set(HRPEC_SOURCE         ${hrpsys_SOURCE_DIR}/src/ec/hrpEC)
@@ -83,8 +79,6 @@ else()
   set(ROBOTHARDWARE_SOURCE ${hrpsys_PREFIX}/share/hrpsys/src/rtc/RobotHardware)
   set(HRPEC_SOURCE         ${hrpsys_PREFIX}/share/hrpsys/src/ec/hrpEC)
 endif()
-include_directories(${catkin_INCLUDE_DIRS} ${openrtm_aist_INCLUDE_DIRS} ${openhrp3_INCLUDE_DIRS} ${hrpsys_INCLUDE_DIRS})
-link_directories(${CATKIN_DEVEL_PREFIX}/lib ${hrpsys_PREFIX}/lib ${openhrp3_LIBRARY_DIRS} /opt/ros/$ENV{ROS_DISTRO}/lib/)
 add_subdirectory(iob)
 
 add_custom_target(hrpsys_choreonoid_iob ALL DEPENDS RobotHardware_choreonoid)


### PR DESCRIPTION
ref: #282 
aptのhrpsysをincludeしようとしてビルドが通らないことが多々あるのでその修正です．
#282 の修正だけではhrpsys src + openrtm apt といった組み合わせの時依然として問題が起こっていたので，そちらの修正をした上でinclude_directoriesやlink_directoriesを整理しました．