### PR TITLE
[hrpsys_choreonoid/launch/run_choreonoid.sh] Kill choreonoid certainly

### DIFF
--- a/hrpsys_choreonoid/launch/run_choreonoid.sh
+++ b/hrpsys_choreonoid/launch/run_choreonoid.sh
@@ -16,6 +16,9 @@ if [ "$(pgrep -x ${choreonoid_exe} | wc -l)" != 0 ]; then
     exit 1
 fi
 
+# Kill choreonoid certainly
+trap "pkill ${choreonoid_exe} -g 0" SIGINT SIGKILL SIGTERM
+
 cnoid_proj=""
 if [ "$(echo $1 | grep \.cnoid$ | wc -l)" == 1 ]; then
     cnoid_proj=$1


### PR DESCRIPTION
Ctrl+Cを押した時，run_choreonoid.shに対してSIGTERMやSIGKILLが呼ばれてしまいChoreonoidが落ちない現象が頻発していたので，確実に落ちるようにしました．
子プロセスのみ落とすはずで， #287 のようにChoreonoidを複数立ち上げる場面でも問題はないはずです．