### PR TITLE
[hrpsys_choreonoid_tutorials/config] Use floor.body instead of floor.wrl

### DIFF
--- a/hrpsys_choreonoid_tutorials/config/CHIDORI_RH_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/CHIDORI_RH_FLAT.cnoid.in
@@ -62,7 +62,7 @@ items:
           plugin: Body
           class: BodyItem
           data: 
-            modelFile: "${SHARE}/model/misc/floor.wrl"
+            modelFile: "${SHARE}/model/misc/floor.body"
             currentBaseLink: "BASE"
             rootPosition: [ 0, 0, -0.1 ]
             rootAttitude: [ 

--- a/hrpsys_choreonoid_tutorials/config/JAXON_BLUE_RH_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_BLUE_RH_FLAT.cnoid.in
@@ -65,7 +65,7 @@ items:
           plugin: Body
           class: BodyItem
           data:
-            modelFile: "${SHARE}/model/misc/floor.wrl"
+            modelFile: "${SHARE}/model/misc/floor.body"
             currentBaseLink: ""
             rootPosition: [ 0, 0, -0.1 ]
             rootAttitude: [

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_FLAT.cnoid.in
@@ -65,7 +65,7 @@ items:
           plugin: Body
           class: BodyItem
           data: 
-            modelFile: "${SHARE}/model/misc/floor.wrl"
+            modelFile: "${SHARE}/model/misc/floor.body"
             currentBaseLink: ""
             rootPosition: [ 0, 0, -0.1 ]
             rootAttitude: [ 

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_RH_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_RH_FLAT.cnoid.in
@@ -65,7 +65,7 @@ items:
           plugin: Body
           class: BodyItem
           data: 
-            modelFile: "${SHARE}/model/misc/floor.wrl"
+            modelFile: "${SHARE}/model/misc/floor.body"
             currentBaseLink: ""
             rootPosition: [ 0, 0, -0.1 ]
             rootAttitude: [ 

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_TUTORIALS.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_TUTORIALS.cnoid.in
@@ -65,7 +65,7 @@ items:
           plugin: Body
           class: BodyItem
           data: 
-            modelFile: "${SHARE}/model/misc/floor.wrl"
+            modelFile: "${SHARE}/model/misc/floor.body"
             currentBaseLink: ""
             rootPosition: [ 0, 0, -0.1 ]
             rootAttitude: [ 


### PR DESCRIPTION
最新版のChoreonoidにはfloor.wrlが消されているので.bodyの方を使用するようにしました．
Version 1.6でも問題なく動作します．