### PR TITLE
update launch files for multi name server

### DIFF
--- a/hrpsys_choreonoid/launch/ros_bridge_choreonoid.launch
+++ b/hrpsys_choreonoid/launch/ros_bridge_choreonoid.launch
@@ -6,6 +6,7 @@
   <arg name="RUN_RVIZ" default="false" />
 
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
 
   <arg name="USE_ROBOTHARDWARE"       default="true" />
   <arg name="USE_WALKING"             default="true"  />
@@ -29,6 +30,7 @@
     <arg name="COLLADA_FILE" value="$(arg COLLADA_FILE)" />
     <arg name="CONF_FILE"    value="$(arg CONF_FILE)" />
     <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <arg name="USE_ROBOTHARDWARE" default="$(arg USE_ROBOTHARDWARE)" />
     <!-- unstable RTC -->
     <arg name="USE_WALKING"               value="$(arg USE_WALKING)" />

--- a/hrpsys_choreonoid/launch/run_choreonoid.sh
+++ b/hrpsys_choreonoid/launch/run_choreonoid.sh
@@ -3,18 +3,18 @@
 ### choose choreonoid binary
 choreonoid_exe='choreonoid'
 
-if [ "$(pgrep -x ${choreonoid_exe} | wc -l)" != 0 ]; then
-    pkill -9 ${choreonoid_exe}
-    echo "****************************************************" 1>&2
-    echo "*                                                  *" 1>&2
-    echo "*                                                  *" 1>&2
-    echo "*   Old choreonoid process was found.              *" 1>&2
-    echo "*   Process has been killed, please start again.   *" 1>&2
-    echo "*                                                  *" 1>&2
-    echo "*                                                  *" 1>&2
-    echo "****************************************************" 1>&2
-    exit 1
-fi
+# if [ "$(pgrep -x ${choreonoid_exe} | wc -l)" != 0 ]; then
+#     pkill -9 ${choreonoid_exe}
+#     echo "****************************************************" 1>&2
+#     echo "*                                                  *" 1>&2
+#     echo "*                                                  *" 1>&2
+#     echo "*   Old choreonoid process was found.              *" 1>&2
+#     echo "*   Process has been killed, please start again.   *" 1>&2
+#     echo "*                                                  *" 1>&2
+#     echo "*                                                  *" 1>&2
+#     echo "****************************************************" 1>&2
+#     exit 1
+# fi
 
 # Kill choreonoid certainly
 trap "pkill ${choreonoid_exe} -g 0" SIGINT SIGKILL SIGTERM

--- a/hrpsys_choreonoid/launch/startup_choreonoid.launch
+++ b/hrpsys_choreonoid/launch/startup_choreonoid.launch
@@ -12,6 +12,7 @@
   <arg name="REALTIME" default="true" />
   <arg name="OUTPUT" default="log"/>
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
   <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="false"/>
 
   <arg name="RobotHardware_conf" default="$(arg CONF_FILE)"/>
@@ -36,6 +37,7 @@
     <arg name="KILL_SERVERS" value="$(arg KILL_SERVERS)" />
     <arg name="REALTIME" value="$(arg REALTIME)" />
     <arg name="corbaport" value="$(arg corbaport)" />
+    <arg name="managerport" value="$(arg managerport)" />
     <arg name="openrtm_openhrp_server_start" value="true"/>
     <arg name="RESPAWN_MODELLOADER" value="false" />
     <arg name="GUI" default="$(arg GUI)" />

--- a/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/chidori_choreonoid.launch
@@ -8,6 +8,8 @@
   <arg name="RUN_RVIZ" default="true" />
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
+  <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
   <!-- robot dependant settings -->
   <arg if="$(arg USE_ROBOTHARDWARE)"
        name="taskname" value="RH_$(arg TASK)" />
@@ -35,6 +37,8 @@
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     <arg name="PROJECT_FILE"   value="$(arg PROJECT_FILE)" />
@@ -53,6 +57,8 @@
   <!-- ros_bridge -->
   <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
   <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="USE_ROBOTHARDWARE" value="$(arg USE_ROBOTHARDWARE)" />
     <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
@@ -69,6 +75,8 @@
 
   <!-- vision setting -->
  <include file="$(find hrpsys_choreonoid_tutorials)/launch/chidori_vision_connect.launch" >
+   <arg name="corbaport" default="$(arg corbaport)" />
+   <arg name="managerport" default="$(arg managerport)" />
    <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
  </include>
 

--- a/hrpsys_choreonoid_tutorials/launch/chidori_vision_connect.launch
+++ b/hrpsys_choreonoid_tutorials/launch/chidori_vision_connect.launch
@@ -3,9 +3,10 @@
   <arg name="OUTPUT" default="log"/>
   <arg name="nameserver" default="localhost" />
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
   <arg name="periodic_rate" default="200" />
 
-  <arg name="openrtm_args" default='-o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
+  <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
 
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
   <env name="LANG" value="C" />

--- a/hrpsys_choreonoid_tutorials/launch/create_environment_sample.launch
+++ b/hrpsys_choreonoid_tutorials/launch/create_environment_sample.launch
@@ -11,6 +11,8 @@
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
   <arg name="LAUNCH_FOOTCOORDS" default="true" />
+  <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
 
   <!-- robot dependant settings -->
   <env name="CHOREONOID_SIMULATION_SETTING" value="$(arg ENVIRONMENT_YAML)" />
@@ -38,6 +40,8 @@
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     <arg name="PROJECT_FILE"   value="dummy_argument" />
@@ -57,6 +61,8 @@
   <!-- ros_bridge -->
   <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
   <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
     <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
@@ -76,10 +82,16 @@
   <!-- vision setting -->
   <ggroup if="$(arg USE_VISION)">
     <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_red_vision_connect.launch" >
+      <arg name="corbaport" default="$(arg corbaport)" />
+      <arg name="managerport" default="$(arg managerport)" />
       <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     </include>
   </ggroup>
-  <include file="$(find hrpsys_choreonoid_tutorials)/launch/fixed_camera_connect.launch" />
+  <include file="$(find hrpsys_choreonoid_tutorials)/launch/fixed_camera_connect.launch" >
+      <arg name="corbaport" default="$(arg corbaport)" />
+      <arg name="managerport" default="$(arg managerport)" />
+  </include>
+
   <!--
   <arg name="launch_multisense_local" default="false" />
   <arg name="launch_multisense_remote" default="false" />

--- a/hrpsys_choreonoid_tutorials/launch/fixed_camera_connect.launch
+++ b/hrpsys_choreonoid_tutorials/launch/fixed_camera_connect.launch
@@ -3,9 +3,10 @@
   <arg name="OUTPUT" default="log"/>
   <arg name="nameserver" default="localhost" />
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
   <arg name="periodic_rate" default="200" />
 
-  <arg name="openrtm_args" default='-o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:FIXED_%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
+  <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:FIXED_%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
 
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
   <env name="LANG" value="C" />

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_blue_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_blue_choreonoid.launch
@@ -14,6 +14,8 @@
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
   <arg name="LAUNCH_FOOTCOORDS" default="true" />
+  <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
 
   <!-- robot dependant settings -->
   <arg if="$(arg USE_ROBOTHARDWARE)"
@@ -47,6 +49,8 @@
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     <arg name="PROJECT_FILE"   value="$(arg PROJECT_FILE)" />
@@ -65,6 +69,8 @@
   <!-- ros_bridge -->
   <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
   <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="USE_ROBOTHARDWARE" value="$(arg USE_ROBOTHARDWARE)" />
     <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
@@ -85,6 +91,8 @@
   <!-- vision setting -->
   <group if="$(arg USE_VISION)">
     <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_blue_vision_connect.launch" >
+      <arg name="corbaport" default="$(arg corbaport)" />
+      <arg name="managerport" default="$(arg managerport)" />
       <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     </include>
   </group>

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
@@ -13,6 +13,8 @@
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
   <arg name="LAUNCH_FOOTCOORDS" default="true" />
+  <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
 
   <!-- robot dependant settings -->
   <arg if="$(arg USE_ROBOTHARDWARE)"
@@ -51,6 +53,8 @@
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     <arg name="PROJECT_FILE"   value="$(arg PROJECT_FILE)" />
@@ -69,6 +73,8 @@
   <!-- ros_bridge -->
   <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
   <include file="$(find hrpsys_choreonoid)/launch/ros_bridge_choreonoid.launch" >
+    <arg name="corbaport" default="$(arg corbaport)" />
+    <arg name="managerport" default="$(arg managerport)" />
     <!-- robot dependant settings -->
     <arg name="USE_ROBOTHARDWARE" value="$(arg USE_ROBOTHARDWARE)" />
     <arg name="SIMULATOR_NAME" value="$(arg BRIDGE_SIMULATOR_NAME)" />
@@ -89,6 +95,8 @@
   <!-- vision setting -->
   <group if="$(arg USE_VISION)">
     <include file="$(find hrpsys_choreonoid_tutorials)/launch/jaxon_red_vision_connect.launch" >
+      <arg name="corbaport" default="$(arg corbaport)" />
+      <arg name="managerport" default="$(arg managerport)" />
       <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" />
     </include>
   </group>

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_vision_connect.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_vision_connect.launch
@@ -3,9 +3,10 @@
   <arg name="OUTPUT" default="log"/>
   <arg name="nameserver" default="localhost" />
   <arg name="corbaport" default="15005" />
+  <arg name="managerport" default="2810" />
   <arg name="periodic_rate" default="200" />
 
-  <arg name="openrtm_args" default='-o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
+  <arg name="openrtm_args" default='-o "corba.master_manager:$(arg nameserver):$(arg managerport)" -o "corba.nameservers:$(arg nameserver):$(arg corbaport)" -o "naming.formats:%n.rtc" -o "exec_cxt.periodic.type:PeriodicExecutionContext" -o "exec_cxt.periodic.rate:$(arg periodic_rate)" -o "logger.file_name:/tmp/rtc%p.log"' />
 
   <env name="RTCTREE_NAMESERVERS" value="$(arg nameserver):$(arg corbaport)" />
   <env name="LANG" value="C" />


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/pull/1255 と https://github.com/start-jsk/rtmros_common/pull/1054 がマージされたので作りなおしました．
今度はROS含め多重起動できると思います．
ipythonの引数に各ポート番号をいい感じに渡せないのが残念ですが・・・
↓起動例

```
ROS_MASTER_URI=http://localhost:21311; rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch corbaport:=25005 managerport:=25006
ROS_MASTER_URI=http://localhost:21311; rviz
ipython -i `rospack find hrpsys_choreonoid_tutorials`/scripts/jaxon_red_setup.py "JAXON_RED(Robot)0"
(defaultでは失敗するので)
rtm.nsport = 25005; rtm.mgrport = 25006; hcf = JAXON_RED_HrpsysConfigurator("JAXON_RED"); hcf.init("JAXON_RED(Robot)0", connect_constraint_force_logger_ports=False);
hcf.abc_svc.goPos(0,0,0)

ROS_MASTER_URI=http://localhost:31311; rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch corbaport:=35005 managerport:=35006
ROS_MASTER_URI=http://localhost:31311; rviz
ipython -i `rospack find hrpsys_choreonoid_tutorials`/scripts/jaxon_red_setup.py "JAXON_RED(Robot)0"
(defaultでは失敗するので)
rtm.nsport = 35005; rtm.mgrport = 35006; hcf = JAXON_RED_HrpsysConfigurator("JAXON_RED"); hcf.init("JAXON_RED(Robot)0", connect_constraint_force_logger_ports=False);
hcf.abc_svc.goPos(0,0,0)
```