### PR TITLE
[hrpsys_choreonoid/add_objects.py] add static_joint option

### DIFF
--- a/hrpsys_choreonoid/launch/add_objects.py
+++ b/hrpsys_choreonoid/launch/add_objects.py
@@ -114,6 +114,26 @@ if world:
                 robot_rootLink.setJointType(cnoid.Body.Link.JointType.FREE_JOINT)
                 robot.updateLinkTree()
 
+        if 'static_joint' in obj_info:
+            static_joint = obj_info['static_joint']
+            if static_joint:
+                if callable(robot.numAllJoints): # include virtual joints
+                    for i in range(robot.numAllJoints()):
+                        robot.joint(i).setJointType(cnoid.Body.Link.JointType.FIXED_JOINT)
+                else:
+                    for i in range(robot.numAllJoints):
+                        robot.joint(i).setJointType(cnoid.Body.Link.JointType.FIXED_JOINT)
+                robot.updateLinkTree()
+
+        if 'static_joints' in obj_info:
+            static_joints = obj_info['static_joints']
+            for j in static_joints:
+                if robot.link(j):
+                    robot.link(j).setJointType(cnoid.Body.Link.JointType.FIXED_JOINT)
+                else:
+                    print("joint: %s not found"%(j), file=sys.stderr)
+            robot.updateLinkTree()
+
         if 'translation' in obj_info:
             trans = obj_info['translation']
             robot_rootLink.setTranslation(trans);


### PR DESCRIPTION
これまで，add_objects.pyで読み込むyamlファイルの，各物体の箇所に
```
static: true
```
と書くと，
その物体のルートリンクはworldに固定されるものの，その物体の関節は固定されませんでした．

room73B2のような物体が多いファイルを読み込むと，環境に存在する物体の関節が多いためシミュレーションが遅くなる(0.1倍速くらい)という問題があったため，
新たに
```
static_joint: true
```
と書くと，物体の関節が固定されるようにしました．

この変更によって，環境の全ての物体に
```
static: true
static_joint: true
```
と書くと，room73B2のような環境であっても，自分の環境ではほぼ1倍速でシミュレーションできるようになりました．