### PR TITLE
Support latest choreonoid

### DIFF
--- a/hrpsys_choreonoid/CMakeLists.txt
+++ b/hrpsys_choreonoid/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_choreonoid)
 
+cmake_policy(SET CMP0003 NEW)
+cmake_policy(SET CMP0057 NEW)
+
 find_package(catkin REQUIRED COMPONENTS roscpp tf)
 
 # activate C++ 11 for choreonoid-1.7

--- a/hrpsys_choreonoid_tutorials/config/CHIDORI_RH_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/CHIDORI_RH_FLAT.cnoid.in
@@ -21,6 +21,7 @@ items:
           class: BodyItem
           data:
             modelFile: "@JSK_MODELS_DIR@/CHIDORI/CHIDORImain_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ -0.0545523187, -0.00278991534, 0.932692459 ]
             rootAttitude: [

--- a/hrpsys_choreonoid_tutorials/config/JAXON_BLUE_RH_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_BLUE_RH_FLAT.cnoid.in
@@ -20,6 +20,7 @@ items:
           class: BodyItem
           data:
             modelFile: "@JSK_MODELS_DIR@/JAXON_BLUE/JAXON_BLUEmain_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ 0.0, 0.0, 1.0235 ]
             rootAttitude: [

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_DOOR.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_DOOR.cnoid.in
@@ -20,6 +20,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/JAXON_JVRC/JAXON_JVRCmain_hrpsys_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ 0.0, -1.5, 1.0185 ]
             rootAttitude: [ 
@@ -162,6 +163,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/models/door_wallMain.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "DOOR_WALL_BASE"
             rootPosition: [ 0.75, 0.5, 0.0 ]
             rootAttitude: [ 

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_DRCBOX.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_DRCBOX.cnoid.in
@@ -20,6 +20,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/JAXON_JVRC/JAXON_JVRCmain_hrpsys_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ 0.0, -1.5, 1.0185 ]
             rootAttitude: [ 
@@ -162,6 +163,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/models/surface_drcbox.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: ""
             rootPosition: [ 0.75, 0.5, 0.95 ]
             rootAttitude: [ 
@@ -186,6 +188,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/models/valve.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: ""
             rootPosition: [ 0.75, -0.37, 0.95 ]
             rootAttitude: [ 
@@ -210,6 +213,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/models/handle.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: ""
             rootPosition: [ 0.22, 0.75, 1.0 ]
             rootAttitude: [ 

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_FLAT.cnoid.in
@@ -20,6 +20,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/JAXON_JVRC/JAXON_JVRCmain_hrpsys_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ 0.0, 0.0, 1.0185 ]
             rootAttitude: [ 

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_LOAD_OBJ.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_LOAD_OBJ.cnoid.in
@@ -20,6 +20,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/JAXON_JVRC/JAXON_JVRCmain_hrpsys_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ 0.0, 0.0, 1.0185 ]
             rootAttitude: [ 

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_LOAD_OBJ_NW.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_LOAD_OBJ_NW.cnoid.in
@@ -20,6 +20,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/JAXON_JVRC/JAXON_JVRCmain_hrpsys_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ 0.0, 0.0, 1.0185 ]
             rootAttitude: [ 

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_RH_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_RH_FLAT.cnoid.in
@@ -20,6 +20,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/JAXON_JVRC/JAXON_JVRCmain_hrpsys_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ 0.0, 0.0, 1.0185 ]
             rootAttitude: [ 

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_RH_LOAD_OBJ.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_RH_LOAD_OBJ.cnoid.in
@@ -20,6 +20,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/JAXON_JVRC/JAXON_JVRCmain_hrpsys_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ 0.0, 0.0, 1.0185 ]
             rootAttitude: [ 

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_TUTORIALS.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_TUTORIALS.cnoid.in
@@ -20,6 +20,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/JAXON_JVRC/JAXON_JVRCmain_hrpsys_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ 0.0, 0.0, 1.0185 ]
             rootAttitude: [ 
@@ -90,6 +91,7 @@ items:
           class: BodyItem
           data:
             modelFile: "../../jvrc_models/models/simple_box.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "BOX"
             rootPosition: [ 0, 3.0, 0.15 ]
             rootAttitude: [

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_VALVE.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_VALVE.cnoid.in
@@ -20,6 +20,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/JAXON_JVRC/JAXON_JVRCmain_hrpsys_bush.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: "WAIST"
             rootPosition: [ 0.0, -1.5, 1.0185 ]
             rootAttitude: [ 
@@ -66,6 +67,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/models/visible_floor.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: ""
             rootPosition: [ 0, 0, -0.1 ]
             rootAttitude: [ 
@@ -162,6 +164,7 @@ items:
           class: BodyItem
           data: 
             modelFile: "../../jvrc_models/models/valve_box.wrl"
+            format: CHOREONOID-BODY
             currentBaseLink: ""
             rootPosition: [ 0.75, 0.5, 0.0 ]
             rootAttitude: [ 


### PR DESCRIPTION
開発版のchoreonoidの変更に対応しました

- cmakeポリシーの変更
- プロジェクトファイルでのロボットモデルの読み込みに関する変更 (https://github.com/s-nakaoka/choreonoid/pull/242#issuecomment-648600032 にある通りformatを追加)

おそらくrelease-1.7で使っている人が殆どだと思いますが，release-1.7でもシミュレーションの起動とgo-posまでは確認しました