### PR TITLE
add from_source.rosinstall

### DIFF
--- a/.from_source.rosinstall
+++ b/.from_source.rosinstall
@@ -1,0 +1,37 @@
+- git:
+    local-name: openhrp3
+    uri: https://github.com/fkanehiro/openhrp3.git
+- git:
+    local-name: hrpsys
+    uri: https://github.com/fkanehiro/hrpsys-base.git
+- git:
+    local-name: rtmros_common
+    uri: https://github.com/start-jsk/rtmros_common.git
+- git:
+    local-name: rtmros_tutorials
+    uri: https://github.com/start-jsk/rtmros_tutorials.git
+- git:
+    local-name: rtmros_choreonoid
+    uri: https://github.com/start-jsk/rtmros_choreonoid.git
+- git:
+    local-name: rtmros_hrp2
+    uri: https://github.com/start-jsk/rtmros_hrp2.git
+# - git:
+#     local-name: trans_system
+#     uri: https://github.com/jsk-ros-pkg/trans_system.git
+- git:
+    local-name: multisense
+    # This repository depends on multisense_ros 3.4.9. We are using forked repository because 3.4.9 fails building on melodic. If https://github.com/start-jsk/rtmros_hrp2/issues/557 is solved, you will use origin/master repository.
+    uri: https://github.com/Naoki-Hiraoka/multisense_ros.git
+    version: 3.4.9_fixed
+#- git:
+#    local-name: multisense
+#    uri: git@github.com:carnegierobotics/multisense_ros.git
+#    version: 3.4.9
+- git:
+    local-name: jsk_control
+    uri: https://github.com/jsk-ros-pkg/jsk_control.git
+- git:
+    local-name: choreonoid
+    uri: https://github.com/choreonoid/choreonoid.git
+    version: release-1.7

--- a/.from_source.rosinstall
+++ b/.from_source.rosinstall
@@ -5,19 +5,19 @@
     local-name: hrpsys
     uri: https://github.com/fkanehiro/hrpsys-base.git
 - git:
-    local-name: rtmros_common
+    local-name: rtm-ros-robotics/rtmros_common
     uri: https://github.com/start-jsk/rtmros_common.git
 - git:
-    local-name: rtmros_tutorials
+    local-name: rtm-ros-robotics/rtmros_tutorials
     uri: https://github.com/start-jsk/rtmros_tutorials.git
 - git:
-    local-name: rtmros_choreonoid
+    local-name: rtm-ros-robotics/rtmros_choreonoid
     uri: https://github.com/start-jsk/rtmros_choreonoid.git
 - git:
-    local-name: rtmros_hrp2
+    local-name: rtm-ros-robotics/rtmros_hrp2
     uri: https://github.com/start-jsk/rtmros_hrp2.git
 # - git:
-#     local-name: trans_system
+#     local-name: jsk-ros-pkg/trans_system
 #     uri: https://github.com/jsk-ros-pkg/trans_system.git
 - git:
     local-name: multisense
@@ -29,7 +29,7 @@
 #    uri: git@github.com:carnegierobotics/multisense_ros.git
 #    version: 3.4.9
 - git:
-    local-name: jsk_control
+    local-name: jsk-ros-pkg/jsk_control
     uri: https://github.com/jsk-ros-pkg/jsk_control.git
 - git:
     local-name: choreonoid

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ roseus `rospack find hrpsys_ros_bridge_tutorials`/euslisp/jaxon_red-interface.l
 (send *ri* :go-pos 1 0 0)
 ```
 
+If you get error, try `export ORBgiopMaxMsgSize=2097152000`.
+
 See also [hrpsys_choreonoid_tutorials/README.md](/hrpsys_choreonoid_tutorials/README.md)
 
 ---

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ catkin build hrpsys_choreonoid_tutorials
 source devel/setup.bash
 rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch
 ```
+Launch another terminal and send command to robot. (python)
+```
+ipython -i `rospack find hrpsys_choreonoid_tutorials`/scripts/jaxon_red_setup.py "JAXON_RED(Robot)0"
+hcf.abc_svc.goPos(1,0,0)
+```
+Launch another terminal and send command to robot. (euslisp)
+```
+roseus `rospack find hrpsys_ros_bridge_tutorials`/euslisp/jaxon_red-interface.l
+(jaxon_red-init)
+(send *ri* :go-pos 1 0 0)
+```
 
 See also [hrpsys_choreonoid_tutorials/README.md](/hrpsys_choreonoid_tutorials/README.md)
 

--- a/README.md
+++ b/README.md
@@ -9,12 +9,21 @@ cd ~/catkin_ws/src
 wstool init .
 wstool set rtm-ros-robotics/rtmros_choreonoid https://github.com/start-jsk/rtmros_choreonoid --git -y
 ```
-Set up workspace
+Set up workspace.
+
+If you install openhrp3 and hrpsys from apt.
 ```
 wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_choreonoid/master/.travis.rosinstall -y
 wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_choreonoid/master/.travis.rosinstall.${ROS_DISTRO} -y
 wstool update
 ```
+
+Else if you install openhrp3 and hrpsys from source.
+```
+wstool merge https://raw.githubusercontent.com/start-jsk/rtmros_choreonoid/master/.from_source.rosinstall -y
+wstool update
+```
+
 Install requisites for choreonoid
 ```
 ./choreonoid/misc/script/install-requisites-ubuntu-16.04.sh # if ubuntu 16.04


### PR DESCRIPTION
README.mdに，hrpsysやopenhrp3をsourceから入れる場合の手順を追加しました．現在のrtmros_choreonoidのwikiに書いてある.rosinstallと同じものです．

@kindsenior 