### PR TITLE
fix README not use private models

### DIFF
--- a/.from_source.rosinstall
+++ b/.from_source.rosinstall
@@ -14,24 +14,12 @@
     local-name: rtm-ros-robotics/rtmros_choreonoid
     uri: https://github.com/start-jsk/rtmros_choreonoid.git
 - git:
-    local-name: rtm-ros-robotics/rtmros_hrp2
-    uri: https://github.com/start-jsk/rtmros_hrp2.git
-# - git:
-#     local-name: jsk-ros-pkg/trans_system
-#     uri: https://github.com/jsk-ros-pkg/trans_system.git
-- git:
-    local-name: multisense
-    # This repository depends on multisense_ros 3.4.9. We are using forked repository because 3.4.9 fails building on melodic. If https://github.com/start-jsk/rtmros_hrp2/issues/557 is solved, you will use origin/master repository.
-    uri: https://github.com/Naoki-Hiraoka/multisense_ros.git
-    version: 3.4.9_fixed
-#- git:
-#    local-name: multisense
-#    uri: git@github.com:carnegierobotics/multisense_ros.git
-#    version: 3.4.9
-- git:
     local-name: jsk-ros-pkg/jsk_control
     uri: https://github.com/jsk-ros-pkg/jsk_control.git
 - git:
     local-name: choreonoid
     uri: https://github.com/choreonoid/choreonoid.git
     version: release-1.7
+- git:
+    local-name: jsk-ros-pkg/jsk_robot
+    uri: https://github.com/jsk-ros-pkg/jsk_robot.git

--- a/.travis.rosinstall
+++ b/.travis.rosinstall
@@ -1,7 +1,10 @@
 - git:
     local-name: choreonoid
-    uri: https://github.com/choreonoid/choreonoid
+    uri: https://github.com/choreonoid/choreonoid.git
     version: release-1.7
 - git:
     local-name: rtm-ros-robotics/rtmros_tutorials
-    uri: https://github.com/start-jsk/rtmros_tutorials
+    uri: https://github.com/start-jsk/rtmros_tutorials.git
+- git:
+    local-name: jsk-ros-pkg/jsk_robot
+    uri: https://github.com/jsk-ros-pkg/jsk_robot.git

--- a/.travis.rosinstall.melodic
+++ b/.travis.rosinstall.melodic
@@ -1,4 +1,4 @@
 # run_depend. not released on melodic
 - git:
-    uri: https://github.com/jsk-ros-pkg/jsk_control
+    uri: https://github.com/jsk-ros-pkg/jsk_control.git
     local-name: jsk-ros-pkg/jsk_control

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ source devel/setup.bash
 ```
 catkin build hrpsys_choreonoid_tutorials
 source devel/setup.bash
-rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch
+rtmlaunch hrpsys_choreonoid_tutorials jaxon_jvrc_choreonoid.launch
 ```
 Launch another terminal and send command to robot. (python)
 ```
@@ -55,14 +55,18 @@ hcf.abc_svc.goPos(1,0,0)
 ```
 Launch another terminal and send command to robot. (euslisp)
 ```
-roseus `rospack find hrpsys_ros_bridge_tutorials`/euslisp/jaxon_red-interface.l
-(jaxon_red-init)
+roseus `rospack find hrpsys_choreonoid_tutorials`/euslisp/jaxon_jvrc-interface.l
+(jaxon_jvrc-init)
 (send *ri* :go-pos 1 0 0)
+(send *ri* :start-grasp)
+(send *ri* :stop-grasp)
+(setq *robot* *jaxon_jvrc*)
+(objects *robot*)
+(send *robot* :reset-manip-pose)
+(send *ri* :angle-vector (send *robot* :angle-vector) 5000)
 ```
 
 If you get error, try `export ORBgiopMaxMsgSize=2097152000`.
-
-If you use the open-source jaxon model, please use jaxon_jvrc_choreonoid.launch instead of jaxon_red_choreonoid.launch.
 
 See also [hrpsys_choreonoid_tutorials/README.md](/hrpsys_choreonoid_tutorials/README.md)
 

--- a/hrpsys_choreonoid_tutorials/CMakeLists.txt
+++ b/hrpsys_choreonoid_tutorials/CMakeLists.txt
@@ -172,6 +172,7 @@ configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_DOOR.cnoid.in ${PROJECT_SO
 configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_RH_FLAT.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_RH_FLAT.cnoid @ONLY)
 configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_LOAD_OBJ.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_LOAD_OBJ.cnoid @ONLY)
 configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_LOAD_OBJ_NW.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_LOAD_OBJ_NW.cnoid @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_RH_LOAD_OBJ.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_RH_LOAD_OBJ.cnoid @ONLY)
 
 configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_TUTORIALS.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_TUTORIALS.cnoid @ONLY)
 

--- a/hrpsys_choreonoid_tutorials/README.md
+++ b/hrpsys_choreonoid_tutorials/README.md
@@ -1,26 +1,23 @@
 
 ## **how to use**
 ### **JAXON environments**
-simplest version:
+simplest version: (JAXON_RED_RH_FLAT.cnoid)
 ```
-$ rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch
-```
-DRCBOX & vision:
-```
-$ rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch TASK:=DRCBOX
-$ roslaunch hrpsys_choreonoid_tutorials jaxon_multisense_local.launch
-```
-add VRML objects using yaml:
-```
-rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch LOAD_OBJECTS:=true ENVIRONMENT_YAML:=$(rospack find hrpsys_choreonoid_tutorials)/config/simple_step.yaml
+$ rtmlaunch hrpsys_choreonoid_tutorials jaxon_jvrc_choreonoid.launch
 ```
 
-If you use the open-source jaxon model, please use jaxon_jvrc_choreonoid.launch instead of jaxon_red_choreonoid.launch.
+DRCBOX: (JAXON_RED_DRCBOX.cnoid)
+```
+$ rtmlaunch hrpsys_choreonoid_tutorials jaxon_jvrc_choreonoid.launch USE_ROBOTHARDWARE:=false TASK:=DRCBOX
+```
+
+add VRML objects using yaml: (JAXON_RED_RH_LOAD_OBJ.cnoid)
+```
+$ rtmlaunch hrpsys_choreonoid_tutorials jaxon_jvrc_choreonoid.launch LOAD_OBJECTS:=true ENVIRONMENT_YAML:=$(rospack find hrpsys_choreonoid_tutorials)/config/simple_step.yaml
+```
 
 If simulatitors often end abnormaly, the stand-alone roscore may solve the problem (Please launch the roscore before rtmlaunch command.).
 This enables you to reuse a single '*ri*' in simurations and to skip '(jaxon_red-init)'.
-
-オープンソースのJAXONモデルを用いている場合はjaxon_red_choreonoid.launchの代わりにjaxon_jvrc_choreonoid.launchを使う．
 
 シミュレーションが頻繁に突然終了する時には，roscoreを別で立ち上げておくと改善される場合がある．
 また，roscoreを立ち上げておくと，毎回シミュレーションを立ち上げなおしてもroseusにおいて`*ri*`を保持することができ，angle-vectorなどを使うために`(jaxon_red-init)`などし直す必要がない．

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_jvrc_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_jvrc_choreonoid.launch
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="TASK" default="TUTORIALS" />
+  <arg name="TASK" default="FLAT" />
   <arg name="USE_ROBOTHARDWARE" default="true" />
   <arg name="ENVIRONMENT_YAML" default="$(find hrpsys_choreonoid_tutorials)/config/footsal.yaml" />
   <arg name="LOAD_OBJECTS" default="false" />

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid.launch
@@ -15,13 +15,13 @@
   <arg name="LAUNCH_FOOTCOORDS" default="true" />
 
   <!-- robot dependant settings -->
-  <arg if="$(arg USE_ROBOTHARDWARE)"
-       name="taskname" value="RH_$(arg TASK)" />
-  <arg unless="$(arg USE_ROBOTHARDWARE)"
-       name="taskname" value="$(arg TASK)" />
   <arg if="$(arg LOAD_OBJECTS)"
-       name="taskname_obj" value="LOAD_OBJ" />
+       name="taskname" value="LOAD_OBJ" />
   <arg unless="$(arg LOAD_OBJECTS)"
+       name="taskname" value="$(arg TASK)" />
+  <arg if="$(arg USE_ROBOTHARDWARE)"
+       name="taskname_obj" value="RH_$(arg taskname)" />
+  <arg unless="$(arg USE_ROBOTHARDWARE)"
        name="taskname_obj" value="$(arg taskname)" />
   <arg if="$(arg NO_SCENE)"
        name="taskname_last" value="$(arg taskname_obj)_NW" />


### PR DESCRIPTION
https://github.com/start-jsk/rtmros_choreonoid/pull/345
rtmros_chorenoidのREADMEやインストール手順では、privateなモデルを使用しないようにしました。

また、jaxon_jvrc_choreonoid.launchを実行するとjsk_robot_startupとcnoidファイルが無いエラーになったので、jsk_robotを.rosinstallに追加し、jaxon_jvrc_choreonoid.launchのtaskをcnoidファイルが存在するものに変更しました。