### PR TITLE
fix for TABLIS simulation and enable JCM_TORQUE mode

### DIFF
--- a/hrpsys_choreonoid_tutorials/config/TABLIS_BASE_RH_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/TABLIS_BASE_RH_FLAT.cnoid.in
@@ -58,7 +58,7 @@ items:
                 configurationMode: Use Configuration File
                 AutoConnect: false
                 InstanceName: TABLIS(Robot)0
-                bodyPeriodicRate: 0.002
+                bodyPeriodicRate: 0.001
         -
           id: 4
           name: "floor"

--- a/hrpsys_choreonoid_tutorials/config/TABLIS_RH_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/TABLIS_RH_FLAT.cnoid.in
@@ -58,7 +58,7 @@ items:
                 configurationMode: Use Configuration File
                 AutoConnect: false
                 InstanceName: TABLIS(Robot)0
-                bodyPeriodicRate: 0.002
+                bodyPeriodicRate: 0.001
         -
           id: 4
           name: "floor"

--- a/hrpsys_choreonoid_tutorials/config/TABLIS_RH_FLAT.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/TABLIS_RH_FLAT.cnoid.in
@@ -65,7 +65,7 @@ items:
           plugin: Body
           class: BodyItem
           data:
-            modelFile: "${SHARE}/model/misc/floor.wrl"
+            modelFile: "${SHARE}/model/misc/floor.body"
             currentBaseLink: ""
             rootPosition: [ 0, 0, -0.1 ]
             rootAttitude: [

--- a/hrpsys_choreonoid_tutorials/launch/tablis_base_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/tablis_base_choreonoid.launch
@@ -12,6 +12,7 @@
   <arg name="USE_VISION" default="false" />
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
+  <arg name="hrpsys_opt_rtc_config_args" default="" />
   <arg name="LAUNCH_FOOTCOORDS" default="true" />
 
   <!-- robot dependant settings -->
@@ -33,16 +34,23 @@
   <arg unless="$(arg USE_ROBOTHARDWARE)"
        name="BRIDGE_SIMULATOR_NAME" default="$(arg SIMULATOR_NAME)" />
   <arg name="MODEL_FILE"     value="$(find jsk_models)/TABLIS/TABLISmain_base.wrl"/>
-  <arg name="COLLADA_FILE"   value="$(find hrpsys_ros_bridge_tutorials)/models/TABLIS.urdf"/>
+  <arg name="COLLADA_FILE"   value="$(find hrpsys_ros_bridge_tutorials)/models/TABLIS_SENSORS.urdf"/>
   <arg name="CONF_FILE"      value="$(find hrpsys_ros_bridge_tutorials)/models/TABLIS.conf"/>
-  <arg name="HRPSYS_PY_PKG"  value="hrpsys_choreonoid_tutorials"/>
+  <arg name="HRPSYS_PY_PKG"  default="hrpsys_choreonoid_tutorials"/>
   <arg if="$(arg USE_ROBOTHARDWARE)"
-       name="HRPSYS_PY_NAME" value="tablis_rh_setup.py" />
+       name="HRPSYS_PY_NAME" default="tablis_base_rh_setup.py" />
   <arg unless="$(arg USE_ROBOTHARDWARE)"
-       name="HRPSYS_PY_NAME" value="tablis_setup.py" />
+       name="HRPSYS_PY_NAME" default="tablis_base_setup.py" />
   <arg name="CONTROLLER_CONFIG"
        value="$(find hrpsys_ros_bridge_tutorials)/models/TABLIS_controller_config.yaml" />
   <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="false"/>
+
+  <!-- unstable RTC -->
+  <arg name="USE_WALKING"               default="true" />
+  <arg name="USE_IMPEDANCECONTROLLER"   default="true" />
+  <arg name="USE_EMERGENCYSTOPPER"    default="true"  />
+  <arg name="USE_REFERENCEFORCEUPDATER" default="false" />
+  <arg name="USE_OBJECTCONTACTTURNAROUNDDETECTOR" default="false" />
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
@@ -59,6 +67,7 @@
     <arg name="REALTIME" value="$(arg REALTIME)" />
     <arg name="GUI" value="$(arg GUI)" />
     <arg name="hrpsys_precreate_rtc" value="$(arg hrpsys_precreate_rtc)" />
+    <arg name="hrpsys_opt_rtc_config_args" value="$(arg hrpsys_opt_rtc_config_args)" />
     <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="$(arg CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS)"/>
   </include>
   <!-- ros_bridge -->
@@ -70,12 +79,12 @@
     <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
     <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>
     <arg name="CONF_FILE"      value="$(arg CONF_FILE)" />
+    <!-- unstable RTC -->
+    <arg name="USE_IMPEDANCECONTROLLER"   value="$(arg USE_IMPEDANCECONTROLLER)" />
+    <arg name="USE_WALKING"               value="$(arg USE_WALKING)" />
+    <arg name="USE_EMERGENCYSTOPPER"      value="$(arg USE_EMERGENCYSTOPPER)" />
+    <arg name="USE_REFERENCEFORCEUPDATER" value="$(arg USE_REFERENCEFORCEUPDATER)" />
+    <arg name="USE_OBJECTCONTACTTURNAROUNDDETECTOR" value="$(arg USE_OBJECTCONTACTTURNAROUNDDETECTOR)" />
   </include>
-
-  <!-- additional ros_bridge -->
-  <include file="$(find jsk_footstep_controller)/launch/hrp2jsk_footcoords.launch"
-           if="$(arg LAUNCH_FOOTCOORDS)" />
-  <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server"
-        if="$(arg LAUNCH_FOOTCOORDS)" />
 
 </launch>

--- a/hrpsys_choreonoid_tutorials/launch/tablis_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/tablis_choreonoid.launch
@@ -1,6 +1,5 @@
 <launch>
   <arg name="TASK" default="FLAT" />
-  <!-- <arg name="USE_ROBOTHARDWARE" default="false" /> -->
   <arg name="USE_ROBOTHARDWARE" default="true" />
   <arg name="ENVIRONMENT_YAML" default="$(find hrpsys_choreonoid_tutorials)/config/flat.yaml" />
   <arg name="LOAD_OBJECTS" default="false" />
@@ -13,6 +12,7 @@
   <arg name="USE_VISION" default="false" />
   <arg name="GUI" default="true" />
   <arg name="hrpsys_precreate_rtc" default=""/>
+  <arg name="hrpsys_opt_rtc_config_args" default="" />
   <arg name="LAUNCH_FOOTCOORDS" default="true" />
 
   <!-- robot dependant settings -->
@@ -34,16 +34,23 @@
   <arg unless="$(arg USE_ROBOTHARDWARE)"
        name="BRIDGE_SIMULATOR_NAME" default="$(arg SIMULATOR_NAME)" />
   <arg name="MODEL_FILE"     value="$(find jsk_models)/TABLIS/TABLISmain.wrl"/>
-  <arg name="COLLADA_FILE"   value="$(find hrpsys_ros_bridge_tutorials)/models/TABLIS.urdf"/>
+  <arg name="COLLADA_FILE"   value="$(find hrpsys_ros_bridge_tutorials)/models/TABLIS_SENSORS.urdf"/>
   <arg name="CONF_FILE"      value="$(find hrpsys_ros_bridge_tutorials)/models/TABLIS.conf"/>
-  <arg name="HRPSYS_PY_PKG"  value="hrpsys_choreonoid_tutorials"/>
+  <arg name="HRPSYS_PY_PKG"  default="hrpsys_choreonoid_tutorials"/>
   <arg if="$(arg USE_ROBOTHARDWARE)"
-       name="HRPSYS_PY_NAME" value="tablis_rh_setup.py" />
+       name="HRPSYS_PY_NAME" default="tablis_rh_setup.py" />
   <arg unless="$(arg USE_ROBOTHARDWARE)"
-       name="HRPSYS_PY_NAME" value="tablis_setup.py" />
+       name="HRPSYS_PY_NAME" default="tablis_setup.py" />
   <arg name="CONTROLLER_CONFIG"
        value="$(find hrpsys_ros_bridge_tutorials)/models/TABLIS_controller_config.yaml" />
   <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="false"/>
+
+  <!-- unstable RTC -->
+  <arg name="USE_WALKING"               default="true" />
+  <arg name="USE_IMPEDANCECONTROLLER"   default="true" />
+  <arg name="USE_EMERGENCYSTOPPER"    default="true"  />
+  <arg name="USE_REFERENCEFORCEUPDATER" default="false" />
+  <arg name="USE_OBJECTCONTACTTURNAROUNDDETECTOR" default="false" />
 
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
@@ -60,6 +67,7 @@
     <arg name="REALTIME" value="$(arg REALTIME)" />
     <arg name="GUI" value="$(arg GUI)" />
     <arg name="hrpsys_precreate_rtc" value="$(arg hrpsys_precreate_rtc)" />
+    <arg name="hrpsys_opt_rtc_config_args" value="$(arg hrpsys_opt_rtc_config_args)" />
     <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="$(arg CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS)"/>
   </include>
   <!-- ros_bridge -->
@@ -70,12 +78,22 @@
     <arg name="MODEL_FILE"     value="$(arg MODEL_FILE)" />
     <arg name="COLLADA_FILE"   value="$(arg COLLADA_FILE)"/>
     <arg name="CONF_FILE"      value="$(arg CONF_FILE)" />
+    <!-- unstable RTC -->
+    <arg name="USE_IMPEDANCECONTROLLER"   value="$(arg USE_IMPEDANCECONTROLLER)" />
+    <arg name="USE_WALKING"               value="$(arg USE_WALKING)" />
+    <arg name="USE_EMERGENCYSTOPPER"      value="$(arg USE_EMERGENCYSTOPPER)" />
+    <arg name="USE_REFERENCEFORCEUPDATER" value="$(arg USE_REFERENCEFORCEUPDATER)" />
+    <arg name="USE_OBJECTCONTACTTURNAROUNDDETECTOR" value="$(arg USE_OBJECTCONTACTTURNAROUNDDETECTOR)" />
   </include>
 
   <!--                     -->
   <!-- additional settings -->
   <!--                     -->
   <!-- additional ros_bridge -->
+  <rosparam>
+    footcoords:
+        root_frame_id: BASE_LINK
+  </rosparam>
   <include file="$(find jsk_footstep_controller)/launch/hrp2jsk_footcoords.launch"
            if="$(arg LAUNCH_FOOTCOORDS)" />
   <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server"
@@ -87,14 +105,4 @@
   <!--     <arg name="SIMULATOR_NAME" value="$(arg SIMULATOR_NAME)" /> -->
   <!--   </include> -->
   <!-- </group> -->
-
-
-  <!--
-  <arg name="launch_multisense_local" default="false" />
-  <arg name="launch_multisense_remote" default="false" />
-  <include if="$(arg launch_multisense_local)"
-           file="$(find jaxon_ros_bridge)/launch/jaxon_multisense_local.launch" />
-  <include if="$(arg launch_multisense_remote)"
-           file="$(find hrpsys_ros_bridge_jvrc)/launch/jaxon_jvrc_multisense.launch" />
-  -->
 </launch>

--- a/hrpsys_choreonoid_tutorials/scripts/tablis_base_rh_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/tablis_base_rh_setup.py
@@ -4,9 +4,10 @@ from hrpsys_choreonoid_tutorials.choreonoid_hrpsys_config import *
 
 class TABLIS_HrpsysConfigurator(ChoreonoidHrpsysConfigurator):
     def startABSTIMP (self):
-        self.startAutoBalancer()
+        self.rh_svc.setServoGainPercentage("all",100)
+        # self.startAutoBalancer()
         self.setResetPose()
-        self.startStabilizer()
+        # self.startStabilizer()
 
 if __name__ == '__main__':
     hcf = TABLIS_HrpsysConfigurator("TABLIS")

--- a/hrpsys_choreonoid_tutorials/src/hrpsys_choreonoid_tutorials/choreonoid_hrpsys_config.py
+++ b/hrpsys_choreonoid_tutorials/src/hrpsys_choreonoid_tutorials/choreonoid_hrpsys_config.py
@@ -28,8 +28,9 @@ class ChoreonoidHrpsysConfiguratorOrg(URATAHrpsysConfigurator):
     def setupLogger(self, maxlen=15000):
         HrpsysConfigurator.setupLogger(self, maxlen)
         self.connectLoggerPort(self.rh, 'WAIST') ##
-        self.connectLoggerPort(self.abc, 'rfsensor')
-        self.connectLoggerPort(self.abc, 'lfsensor')
+        if self.abc:
+            self.connectLoggerPort(self.abc, 'rfsensor')
+            self.connectLoggerPort(self.abc, 'lfsensor')
         for pn in filter (lambda x : re.match("Trans_", x), self.rh.ports.keys()):
             self.connectLoggerPort(self.rh, pn)
         ##self.connectLoggerPort(self.abc, 'rhsensor')


### PR DESCRIPTION
https://github.com/start-jsk/rtmros_choreonoid/pull/340 に加えて、
TABLISのシミュレーションを行うために必要だった変更点です。

- TABLIS実機は`JCM_TORQUE`モードで動いているため、`hrpsys_choreonoid`のiobも`JCM_TORQUE`モードに対応させました https://github.com/start-jsk/rtmros_choreonoid/pull/349/commits/6efd6a853e0bb4e989afd68fcc59b859705f4600
- hrpsysをソースから入れても-DROBOT_IOB_VERSION=3でビルドされてしまう問題https://github.com/start-jsk/rtmros_choreonoid/issues/339 を解消しました。https://github.com/start-jsk/rtmros_choreonoid/pull/349/commits/d92e8e6e1b6b682f37168aa2a9351cbc52437b78
- これまでは関節ゲインとして、シミュレーション開始直後は`pdgains_sim_file_name`の値が使われ、`write_pgain`等を一回呼ぶと以降は`pdgains_sim_file_name`の値に`pdgains.file_name`の値を掛けた値が使われていました。シミュレーション開始直後に立てない問題があったので、常に`pdgains_sim_file_name`の値に`pdgains.file_name`の値を掛けた値が使われるようにしました。https://github.com/start-jsk/rtmros_choreonoid/pull/349/commits/520756d61619dedcce3475ee881572b726cb3694  ([参考](https://github.com/start-jsk/rtmros_choreonoid/pull/326#issue-405959857))
- TABLISのcnoidファイルの制御周期を0.001sに変更し、https://github.com/start-jsk/rtmros_tutorials/pull/588 のconfファイルと整合性を取りました。https://github.com/start-jsk/rtmros_choreonoid/pull/349/commits/38204624296c14f9342ba7f76c9a09521d133507
- その他、TABLIS固有のファイルに対する細かな変更。https://github.com/start-jsk/rtmros_choreonoid/pull/349/commits/b3eb38580d7b57e4d28914098d88cf06ec17b99f
- `choreonoid_hrpsys_config.py`をabcが無いロボットでも動くようにするhttps://github.com/start-jsk/rtmros_choreonoid/pull/349/commits/6265821d4a75ad3cedddaf358c319d9cf4c85cd7

masterのシステムでは`JCM_POSITION`モード以外には対応していないので、TABLISもデフォルトでは`JCM_POSITION`モードで立ち上がるようにします。
`rtmlaunch hrpsys_choreonoid_tutorials tablis_choreonoid.launch`だと浮遊リンクバージョンのシミュレーションができ、`rtmlaunch hrpsys_choreonoid_tutorials tablis_base_choreonoid.launch`だと環境に固定されたバージョンのシミュレーションができます。浮遊リンクバージョンのシミュレーションでは一応Stabilizerが入りますが、パラメータの調整がまだなので歩行は難しいです。