### PR TITLE
[hrpsys_choreonoid] build with ROBOT_IOB_VERSION=4 if hrpsys is installed from source

### DIFF
--- a/hrpsys_choreonoid/iob/CMakeLists.txt
+++ b/hrpsys_choreonoid/iob/CMakeLists.txt
@@ -1,8 +1,10 @@
-if(EXISTS ${hrpsys_SOURCE_DIR})
-  add_definitions(-DHRPSYS_PACKAGE_VERSION=\"\\"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\\"\" -DROBOT_IOB_VERSION=4)
-else()
+if(${hrpsys_PREFIX} MATCHES "/opt/ros/.*")
   # ROBOT_IOB_VERSION=4 is not supported in the released hrpsys
+  message ("Build with -DROBOT_IOB_VERSION=3")
   add_definitions(-DHRPSYS_PACKAGE_VERSION=\"\\"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\\"\" -DROBOT_IOB_VERSION=3)
+else()
+  message ("Build with -DROBOT_IOB_VERSION=4")
+  add_definitions(-DHRPSYS_PACKAGE_VERSION=\"\\"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\\"\" -DROBOT_IOB_VERSION=4)
 endif()
 
 # https://github.com/start-jsk/rtmros_choreonoid/issues/296


### PR DESCRIPTION
https://github.com/start-jsk/rtmros_choreonoid/pull/349 の一部です。

https://github.com/start-jsk/rtmros_choreonoid/issues/339 で報告されている、ソースのhrpsysでもROBOT_IOB_VERSIONが3になるバグを直すPRです。

hrpsysのバーションはaptとsourceで同じになっているので、hrpsys_PREFIXが/opt/rosから始まるかどうかでhrpsysがaptかソースかを判定します。

**With hrpsys APT**
```
rtmros_choreonoid/hrpsys_choreonoid/lib$ nm RobotHardware_choreonoid.so
[中略]
                 U write_accelerometer_offset
                 U write_command_angle
                 U write_command_angles
                 U write_command_torques
                 U write_command_velocities
                 U write_dgain
                 U write_digital_output
                 U write_digital_output_with_mask
                 U write_force_offset
                 U write_gyro_sensor_offset
                 U write_pgain
                 U write_power_command
                 U write_servo
```
**With hrpsys SOURCE**
```
rtmros_choreonoid/hrpsys_choreonoid/lib$ nm RobotHardware_choreonoid.so
[中略]
                 U write_accelerometer_offset
                 U write_command_accelerations
                 U write_command_angle
                 U write_command_angles
                 U write_command_torques
                 U write_command_velocities
                 U write_control_mode
                 U write_dgain
                 U write_digital_output
                 U write_digital_output_with_mask
                 U write_disturbance_observer
                 U write_disturbance_observer_gain
                 U write_force_offset
                 U write_gyro_sensor_offset
                 U write_joint_inertia
                 U write_joint_inertias
                 U write_pgain
                 U write_power_command
                 U write_servo
                 U write_torque_dgain
                 U write_torque_pgain
```