### PR TITLE
[hrpsys_choreonoid_tutorials/scripts/jaxon_red_(rh_)setup.py)] rtc in the same order as real 

### DIFF
--- a/hrpsys_choreonoid_tutorials/scripts/jaxon_red_rh_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/jaxon_red_rh_setup.py
@@ -13,7 +13,9 @@ class JAXON_RED_HrpsysConfigurator(ChoreonoidHrpsysConfigurator):
             ['kf', "KalmanFilter"],
             ['vs', "VirtualForceSensor"],
             ['rmfo', "RemoveForceSensorLinkOffset"],
+            ['octd', "ObjectContactTurnaroundDetector"],
             ['es', "EmergencyStopper"],
+            ['rfu', "ReferenceForceUpdater"],
             ['ic', "ImpedanceController"],
             ['abc', "AutoBalancer"],
             ['st', "Stabilizer"],
@@ -21,8 +23,6 @@ class JAXON_RED_HrpsysConfigurator(ChoreonoidHrpsysConfigurator):
             # ['tc', "TorqueController"],
             # ['te', "ThermoEstimator"],
             # ['tl', "ThermoLimiter"],
-            ['rfu', "ReferenceForceUpdater"],
-            ['octd', "ObjectContactTurnaroundDetector"],
             ['hes', "EmergencyStopper"],
             ['el', "SoftErrorLimiter"],
             ['log', "DataLogger"]

--- a/hrpsys_choreonoid_tutorials/scripts/jaxon_red_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/jaxon_red_setup.py
@@ -13,7 +13,9 @@ class JAXON_RED_HrpsysConfigurator(ChoreonoidHrpsysConfiguratorOrg):
             ['kf', "KalmanFilter"],
             ['vs', "VirtualForceSensor"],
             ['rmfo', "RemoveForceSensorLinkOffset"],
+            ['octd', "ObjectContactTurnaroundDetector"],
             ['es', "EmergencyStopper"],
+            ['rfu', "ReferenceForceUpdater"],
             ['ic', "ImpedanceController"],
             ['abc', "AutoBalancer"],
             ['st', "Stabilizer"],
@@ -21,8 +23,6 @@ class JAXON_RED_HrpsysConfigurator(ChoreonoidHrpsysConfiguratorOrg):
             # ['tc', "TorqueController"],
             # ['te', "ThermoEstimator"],
             # ['tl', "ThermoLimiter"],
-            ['rfu', "ReferenceForceUpdater"],
-            ['octd', "ObjectContactTurnaroundDetector"],
             ['hes', "EmergencyStopper"],
             ['el', "SoftErrorLimiter"],
             ['log', "DataLogger"]


### PR DESCRIPTION
実機環境([trans_ros_bridge/urata_real_hrpsys_config.py](https://github.com/jsk-ros-pkg/trans_system/blob/master/trans_ros_bridge/src/trans_ros_bridge/urata_real_hrpsys_config.py))でのrtcのデータ処理順とchoreonoidでのそれが異なっていて，特にrfuなどは1制御周期ずれて動作していたので修正しました．
ひとまずjaxon_red_setup.py, jaxon_red_rh_setup.py のみを修正しましたが，jaxon_blueやchidoriも修正する必要はあるかと思います．