### PR TITLE
Fix footsal

### DIFF
--- a/hrpsys_choreonoid_tutorials/config/footsal.yaml.in
+++ b/hrpsys_choreonoid_tutorials/config/footsal.yaml.in
@@ -6,12 +6,12 @@ obj1:
 obj2:
   name: 'GOAL'
   file: '@jvrc_models_MODEL_DIR@/models/footsal_goal.wrl'
-  translation: [9.5, 0.0, 0.0]
-  rotation: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+  translation: [0.0, 9.5, 0.0]
+  rotation: [[0, -1, 0], [1, 0, 0], [0, 0, 1]]
 obj3:
   name: 'BALL'
   file: '@jvrc_models_MODEL_DIR@/models/yellow_ball.wrl'
-  translation: [2.0, 0.0, 0.12]
+  translation: [0.0, 2.0, 0.12]
   rotation: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 obj4:
   name: 'WALL_BACK'

--- a/hrpsys_choreonoid_tutorials/config/soccer.yaml.in
+++ b/hrpsys_choreonoid_tutorials/config/soccer.yaml.in
@@ -6,12 +6,12 @@ obj1:
 obj2:
   name: 'GOAL'
   file: '@jvrc_models_MODEL_DIR@/models/soccer_goal.wrl'
-  translation: [26.0, 0.0, 0.0]
-  rotation: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+  translation: [0.0, 26.0, 0.0]
+  rotation: [[0, -1, 0], [1, 0, 0], [0, 0, 1]]
 obj3:
   name: 'BALL'
   file: '@jvrc_models_MODEL_DIR@/models/yellow_ball.wrl'
-  translation: [2.0, 0.0, 0.12]
+  translation: [0.0, 2.0, 0.12]
   rotation: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 obj4:
   name: 'WALL_BACK'

--- a/hrpsys_choreonoid_tutorials/euslisp/action_and_perception/kick-ball-demo.l
+++ b/hrpsys_choreonoid_tutorials/euslisp/action_and_perception/kick-ball-demo.l
@@ -94,8 +94,8 @@
 
 (defun ball-is-goalq ()
   (let ((pos (send (get-coords-on-simulation :robot "BALL") :worldpos)))
-    (and (> (elt pos 0) 9600)
-         (> 1560 (elt pos 1) -1560)
+    (and (> (elt pos 1) 9600)
+         (> 1560 (elt pos 0) -1560)
          (> 2200 (elt pos 2) 0))
     ))
 

--- a/hrpsys_choreonoid_tutorials/launch/perception/image_processing.launch
+++ b/hrpsys_choreonoid_tutorials/launch/perception/image_processing.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="gui" default="false" />
+  <arg name="resized_gui" default="false" />
   <arg name="MANAGER" value="color_filter_nodelet_manager" />
   <arg name="INPUT_LEFT_IMAGE"  default="/multisense_local/left/image_rect_color" />
   <arg name="INPUT_RIGHT_IMAGE" default="/multisense_local/right/image_rect_color" />
@@ -65,6 +66,32 @@
     <node name="right_image_view"
           pkg="image_view2" type="image_view2">
       <remap from="image" to="right_hsv_color/image" />
+    </node>
+  </group>
+  <group if="$(arg resized_gui)">
+    <node name="left_resize"
+          pkg="nodelet" type="nodelet"
+          args="load image_proc/resize $(arg MANAGER)" >
+      <remap from="image" to="left_hsv_color/image" />
+      <param name="scale_width" value="0.5" />
+      <param name="scale_height" value="0.5" />
+    </node>
+    <node name="right_resize"
+          pkg="nodelet" type="nodelet"
+          args="load image_proc/resize $(arg MANAGER)" >
+      <remap from="image" to="right_hsv_color/image" />
+      <param name="scale_width" value="0.5" />
+      <param name="scale_height" value="0.5" />
+    </node>
+    <node name="left_image_view_resized"
+          pkg="image_view2" type="image_view2">
+      <remap from="image" to="left_resize/image" />
+      <param name="autosize" value="true" />
+    </node>
+    <node name="right_image_view_resized"
+          pkg="image_view2" type="image_view2">
+      <remap from="image" to="right_resize/image" />
+      <param name="autosize" value="true" />
     </node>
   </group>
 

--- a/hrpsys_choreonoid_tutorials/launch/perception/tracking_recognition.launch
+++ b/hrpsys_choreonoid_tutorials/launch/perception/tracking_recognition.launch
@@ -1,8 +1,9 @@
 <launch>
   <arg name="gui" default="false" />
-
+  <arg name="resized_gui" default="false" />
   <include file="$(find hrpsys_choreonoid_tutorials)/launch/perception/image_processing.launch" >
     <arg name="gui" value="$(arg gui)" />
+    <arg name="resized_gui" value="$(arg resized_gui)" />
   </include>
 
   <node type="calc-target-point.l"


### PR DESCRIPTION
jaxonのシミュレーションでRobotHardwareを使うバージョンがデフォルトになったことに伴って、標準のロボット方向が違ってしまったため、環境側をロボットの方向に合わせました。

また、画像認識で小さい画面が出るようにしました。

現状のrtmros_choreonoidで、以下のコマンドで
rtmlaunch hrpsys_choreonoid_tutorials jaxon_jvrc_choreonoid.launch
roslaunch hrpsys_choreonoid_tutorials tracking_recognition.launch resized_gui:=true
roseus $(rospack find hrpsys_choreonoid_tutorials)/euslisp/action_and_perception/kick-ball-demo.l '(kick-ball-to-goal-demo)'

以下と同様にロボットシミュレーションができることを確認しました。
https://www.youtube.com/watch?v=tCI5L__FYic