### PR TITLE
[jaxon_red_setup.py][jaxon_red_rh_setup.py] do not set error limit to motor_joint (multisense)

### DIFF
--- a/hrpsys_choreonoid_tutorials/scripts/jaxon_blue_rh_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/jaxon_blue_rh_setup.py
@@ -42,7 +42,6 @@ class JAXON_BLUE_HrpsysConfigurator(ChoreonoidHrpsysConfigurator):
 
     def startABSTIMP (self):
         ### not used on hrpsys
-        # self.el_svc.setServoErrorLimit("motor_joint",   sys.float_info.max)
         # self.el_svc.setServoErrorLimit("RARM_F_JOINT0", sys.float_info.max)
         # self.el_svc.setServoErrorLimit("RARM_F_JOINT1", sys.float_info.max)
         # self.el_svc.setServoErrorLimit("LARM_F_JOINT0", sys.float_info.max)

--- a/hrpsys_choreonoid_tutorials/scripts/jaxon_red_rh_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/jaxon_red_rh_setup.py
@@ -42,7 +42,6 @@ class JAXON_RED_HrpsysConfigurator(ChoreonoidHrpsysConfigurator):
 
     def startABSTIMP (self):
         ### not used on hrpsys
-        self.el_svc.setServoErrorLimit("motor_joint",   sys.float_info.max)
         self.el_svc.setServoErrorLimit("RARM_F_JOINT0", sys.float_info.max)
         self.el_svc.setServoErrorLimit("RARM_F_JOINT1", sys.float_info.max)
         self.el_svc.setServoErrorLimit("LARM_F_JOINT0", sys.float_info.max)

--- a/hrpsys_choreonoid_tutorials/scripts/jaxon_red_setup.py
+++ b/hrpsys_choreonoid_tutorials/scripts/jaxon_red_setup.py
@@ -42,7 +42,6 @@ class JAXON_RED_HrpsysConfigurator(ChoreonoidHrpsysConfiguratorOrg):
 
     def startABSTIMP (self):
         ### not used on hrpsys
-        self.el_svc.setServoErrorLimit("motor_joint",   sys.float_info.max)
         self.el_svc.setServoErrorLimit("RARM_F_JOINT0", sys.float_info.max)
         self.el_svc.setServoErrorLimit("RARM_F_JOINT1", sys.float_info.max)
         self.el_svc.setServoErrorLimit("LARM_F_JOINT0", sys.float_info.max)


### PR DESCRIPTION
motor_joint(multisenseのチルトレーザ)関節のjointIdが設定されていないため，
https://github.com/start-jsk/rtmros_choreonoid/blob/be0a77e942bfa9f2fa3391f53cc1a8ef991f8754/hrpsys_choreonoid_tutorials/scripts/jaxon_red_rh_setup.py#L45
を行うとhrpsyが落ちる場合があることの修正です

このPRがなくても
https://github.com/fkanehiro/hrpsys-base/pull/1315
にてhrpsysが落ちること自体は解決されますが，既にmultisenseがSoftErrorLimiterの監視対象から外れているので設定する必要もないため，limitの設定を除外しました