### PR TITLE
[hrpsys_choreonoid] Choreonoid Bridge Shm

### DIFF
--- a/hrpsys_choreonoid/CMakeLists.txt
+++ b/hrpsys_choreonoid/CMakeLists.txt
@@ -3,6 +3,9 @@ project(hrpsys_choreonoid)
 
 cmake_policy(SET CMP0003 NEW)
 cmake_policy(SET CMP0057 NEW)
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Release)
+endif()
 
 find_package(catkin REQUIRED COMPONENTS roscpp tf)
 
@@ -70,6 +73,24 @@ if(${cnoid-plugin_FOUND})
   ##
   add_executable(ImuROSBridge src/ImuROSBridge.cpp src/ImuROSBridgeComp.cpp)
   target_link_libraries(ImuROSBridge ${openrtm_aist_LIBRARIES} ${cnoid-plugin_LIBRARIES} ${Boost_LIBRARIES} ${hrpsys_LIBRARIES} ${catkin_LIBRARIES})
+  ##
+  add_library(CnoidHrpsysChoreonoidPlugin src/CnoidHrpsysChoreonoidPlugin.cpp src/ClockPublisherItem.cpp src/ClockShmItem.cpp src/OdometryPublisherItem.cpp src/DepthCameraPublisherItem.cpp)
+  target_link_libraries(CnoidHrpsysChoreonoidPlugin ${catkin_LIBRARIES} ${cnoid-plugin_LIBRARIES})
+  set_target_properties(CnoidHrpsysChoreonoidPlugin PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CHOREONOID_PLUGIN_DIR})
+  ##
+  find_package(trans_vm REQUIRED)
+  add_library(BridgeShmController src/BridgeShmController.cpp)
+  target_link_libraries(BridgeShmController ${catkin_LIBRARIES} ${cnoid-plugin_LIBRARIES})
+  target_include_directories(BridgeShmController PUBLIC ${trans_vm_SOURCE_PREFIX}/include)
+  set_target_properties(BridgeShmController PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CHOREONOID_PLUGIN_DIR}/simplecontroller
+    LIBRARY_OUTPUT_DIRECTORY ${CHOREONOID_PLUGIN_DIR}/simplecontroller
+    PREFIX "")
+  ##
+  add_library(ShmTimePeriodicExecutionContext src/ShmTimePeriodicExecutionContext.cpp)
+  target_link_libraries(ShmTimePeriodicExecutionContext ${openrtm_aist_LIBRARIES} ${catkin_LIBRARIES})
+  set_target_properties(ShmTimePeriodicExecutionContext PROPERTIES PREFIX "")
+  set_target_properties(ShmTimePeriodicExecutionContext PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/lib)
 endif()
 
 ## Build only choreonoid iob

--- a/hrpsys_choreonoid/package.xml
+++ b/hrpsys_choreonoid/package.xml
@@ -20,6 +20,7 @@
   <build_depend>tf</build_depend>
   <build_depend>openrtm_aist</build_depend>
   <build_depend>yaml-cpp</build_depend>
+  <build_depend>trans_vm</build_depend>
 
   <run_depend>hrpsys</run_depend>
   <run_depend>openhrp3</run_depend>
@@ -28,6 +29,7 @@
   <run_depend>tf</run_depend>
   <run_depend>openrtm_aist</run_depend>
   <run_depend>yaml-cpp</run_depend>
+  <run_depend>hrpsys_trans_bridge</run_depend>
 
   <export>
   </export>

--- a/hrpsys_choreonoid/src/BridgeShmController.cpp
+++ b/hrpsys_choreonoid/src/BridgeShmController.cpp
@@ -1,0 +1,291 @@
+#include <cnoid/SimpleController>
+#include <cnoid/RateGyroSensor>
+#include <cnoid/AccelerationSensor>
+#include <cnoid/ForceSensor>
+#include <vector>
+#include <iostream>
+#include <fstream>
+
+#include "../controller/system_shm.c"
+#include "../controller/myshm.h"
+#include "../controller/servo_shm.h"
+
+using namespace cnoid;
+
+class BridgeShmController : public SimpleController
+{
+  SimpleControllerIO* io;
+  BodyPtr robot;
+  double dt;
+
+  std::vector<double> hardware_pgain;
+  std::vector<double> hardware_dgain;
+  std::vector<double> hardware_tqpgain;
+  std::vector<double> hardware_tqdgain;
+
+  struct servo_shm *s_shm;
+  unsigned long long frame_counter=0;
+
+  void readGainFile(const std::string& pdGainsSimFileName) {
+    hardware_pgain.resize(robot->numJoints(),0);
+    hardware_dgain.resize(robot->numJoints(),0);
+    hardware_tqpgain.resize(robot->numJoints(),0);
+    hardware_tqdgain.resize(robot->numJoints(),0);
+
+    std::ifstream gain;
+    gain.open(pdGainsSimFileName.c_str());
+
+    if (gain.is_open()) {
+      io->os() << "[BridgeShmController] Gain file [" << pdGainsSimFileName << "] opened" << std::endl;
+      double tmp;
+      int i = 0;
+      for (; i < robot->numJoints(); i++) {
+
+      retry:
+        {
+          std::string str;
+          if (std::getline(gain, str)) {
+            if (str.empty())   goto retry;
+            if (str[0] == '#') goto retry;
+
+            std::istringstream sstrm(str);
+            sstrm >> tmp;
+            hardware_pgain[i] = tmp;
+            if(sstrm.eof()) goto next;
+            sstrm >> tmp;
+            hardware_dgain[i] = tmp;
+            if(sstrm.eof()) goto next;
+            sstrm >> tmp;
+            hardware_tqpgain[i] = tmp;
+            if(sstrm.eof()) goto next;
+            sstrm >> tmp;
+            hardware_tqdgain[i] = tmp;
+          } else {
+            i--;
+            break;
+          }
+        }
+
+      next:
+        io->os() << "joint: " << i << ", P: " << hardware_pgain[i] << ", D: " << hardware_dgain[i] << ", tqP: " << hardware_tqpgain[i] << ", tqD: " << hardware_tqdgain[i] << std::endl;
+      }
+      gain.close();
+      if (i != robot->numJoints()) {
+        io->os() << "\e[0;31m[BridgeShmController] Gain file [" << pdGainsSimFileName << "] does not contain gains for all joints\e[0m" << std::endl;
+      }
+    } else {
+      io->os() << "\e[0;31m[BridgeShmController] Gain file [" << pdGainsSimFileName << "] not opened\e[0m" << std::endl;
+    }
+  }
+
+  void initialize_shm(int shm_key, bool servoOff = false)
+  {
+    io->os() << "[BridgeShmController] set_shared_memory " << shm_key << std::endl;
+    s_shm = (struct servo_shm *)set_shared_memory(shm_key, sizeof(struct servo_shm));
+    if (s_shm == NULL) {
+      io->os() << "[BridgeShmController] set_shared_memory failed" << std::endl;
+      exit(1);
+    }
+
+    // initialize shm
+    s_shm->set_ref_vel = 0;
+    s_shm->calib_mode = 0;
+    s_shm->disable_alert_on_servo_on = 0;
+
+    for (int i = 0; i < robot->numJoints(); i++) {
+      s_shm->ref_angle[i] = robot->joint(i)->q();
+      s_shm->ref_vel[i] = 0.0;
+      s_shm->ref_torque[i] = 0.0;
+      s_shm->pgain[i] = 1.0;
+      s_shm->dgain[i] = 1.0;
+      s_shm->torque_pgain[i] = 0.0;
+      s_shm->torque_dgain[i] = 0.0;
+      for (int j = 0; j < (int)(sizeof(s_shm->subgain[0]) / sizeof(s_shm->subgain[0][0])); j++){
+        s_shm->subgain[i][j] = 0.0;
+      }
+      s_shm->motor_num[i] = 1;
+      s_shm->controlmode[i] = SERVOMODE_POSITION;
+      s_shm->servo_on[i] = 0;
+      s_shm->servo_off[i] = 0;
+      s_shm->torque0[i] = 0;
+      s_shm->joint_enable[i] = 1;
+      s_shm->joint_offset[i] = 0;
+      if (servoOff) {
+        s_shm->is_servo_on[i] = 0;
+        s_shm->servo_state[0][i] = 0x0800;
+        s_shm->loopback[i] = 1;
+      } else {
+        s_shm->is_servo_on[i] = 1;
+        s_shm->servo_state[0][i] = 0x0000;
+        s_shm->loopback[i] = 0;
+      }
+    }
+  }
+
+  void write_shm() {
+    s_shm->frame = (int)frame_counter; frame_counter++;
+    s_shm->received_packet_cnt = 0;
+    s_shm->jitter = 0.0;
+
+    for (int i = 0; i < robot->numJoints(); i++){
+      s_shm->cur_angle[i] = robot->joint(i)->q();
+      s_shm->abs_angle[i] = robot->joint(i)->q();
+      s_shm->cur_vel[i] = robot->joint(i)->dq();
+      s_shm->cur_torque[i] = robot->joint(i)->u();
+      s_shm->motor_current[0][i] = robot->joint(i)->u();
+      s_shm->motor_temp[0][i] = 0.0;
+      s_shm->motor_outer_temp[0][i] = 0.0;
+      s_shm->motor_output[0][i] = 0.0;
+      s_shm->board_vin[0][i] = 0.0;
+      s_shm->board_vdd[0][i] = 0.0;
+      s_shm->comm_normal[0][i] = 1;
+      s_shm->h817_rx_error0[0][i] = 0.0;
+      s_shm->h817_rx_error1[0][i] = 0.0;
+      s_shm->hole_status[0][i] = 0x11;
+      s_shm->torque_coef_current[i] = 0.0;
+      s_shm->torque_coef_inertia[i] = 0.0;
+      s_shm->torque_coef_coulombfric[i] = 0.0;
+      s_shm->torque_coef_viscousfric[i] = 0.0;
+    }
+    {
+      const DeviceList<RateGyroSensor>& rateGyroSensors = robot->devices();
+      for(int i=0; i < rateGyroSensors.size() && i < MAX_IMU_NUM/* defined in servo_shm.h */; i++){
+        for (int j=0; j<3; j++) s_shm->body_omega[rateGyroSensors[i]->id()][j] = rateGyroSensors[i]->w()[j];
+      }
+    }
+    {
+      const DeviceList<AccelerationSensor>& accelerationSensors = robot->devices();
+      for(int i=0; i < accelerationSensors.size() && i < MAX_IMU_NUM/* defined in servo_shm.h */; i++){
+        for (int j=0; j<3; j++) s_shm->body_acc[accelerationSensors[i]->id()][j] = accelerationSensors[i]->dv()[j];
+      }
+    }
+    {
+      const DeviceList<ForceSensor>& forceSensors = robot->devices();
+      for(int i=0; i < forceSensors.size() && i < MAX_FSENSOR_NUM/* defined in servo_shm.h */ ; i++){
+        for (int j=0; j<6; j++) s_shm->reaction_force[forceSensors[i]->id()][j] = forceSensors[i]->F()[j];
+      }
+    }
+  }
+
+  void read_shm_and_control() {
+    for (int i = 0; i < robot->numJoints(); i++){
+      Link* joint = robot->joint(i);
+
+      if (s_shm->servo_off[i]){
+        //do_power_off
+        s_shm->servo_state[0][i] = 0x0800;
+        s_shm->is_servo_on[i] = 0;
+        s_shm->servo_off[i] = 0;
+      }
+      else if (s_shm->servo_on[i]) {
+        if (s_shm->joint_enable[i]) {
+          //do_power_on
+          s_shm->servo_state[0][i] = 0x0000;
+          s_shm->is_servo_on[i] = 1;
+        }
+        s_shm->servo_on[i] = 0;
+      }
+
+      if ( s_shm->is_servo_on[i] == 1 && s_shm->loopback[i] == 0 ) {
+        double qref = (s_shm->loopback[i] == 1) ? s_shm->cur_angle[i] : s_shm->ref_angle[i];
+        double dqref = s_shm->ref_vel[i];
+        double qact = joint->q();
+        double dqact = joint->dq();
+        float limited_pgain = (s_shm->pgain[i] < 0.0) ? 0.0 : s_shm->pgain[i];
+        float limited_dgain = (s_shm->dgain[i] < 0.0) ? 0.0 : s_shm->dgain[i];
+        float limited_torque_pgain = (s_shm->torque_pgain[i] < 0.0) ? 0.0 : s_shm->torque_pgain[i];
+        float limited_torque_dgain = (s_shm->torque_dgain[i] < 0.0) ? 0.0 : s_shm->torque_dgain[i];
+        double u=0;
+        switch(s_shm->controlmode[i]){
+        case SERVOMODE_POSITION_TORQUE:
+        case SERVOMODE_POSITION_FFTORQUE:
+          u = (qref - qact) * limited_pgain * hardware_pgain[i] + (dqref - dqact) * limited_dgain * hardware_dgain[i] + s_shm->ref_torque[i] * limited_torque_pgain * hardware_tqpgain[i];
+          break;
+        case SERVOMODE_POSITION:
+          u = (qref - qact) * limited_pgain * hardware_pgain[i] + (dqref - dqact) * limited_dgain * hardware_dgain[i];
+          break;
+        default:
+          break;
+        }
+        joint->u() = u;
+      } else {
+        joint->u() = 0;
+      }
+    }
+  }
+
+public:
+
+  virtual bool initialize(SimpleControllerIO* io_) override
+  {
+    io = io_;
+    robot = io->body();
+    dt = io->timeStep();
+
+    const DeviceList<RateGyroSensor>& rateGyroSensors = robot->devices();
+    for(int i=0; i < rateGyroSensors.size(); i++){
+      io->enableInput(rateGyroSensors[i]);
+    }
+    const DeviceList<AccelerationSensor>& accelerationSensors = robot->devices();
+    for(int i=0; i < accelerationSensors.size(); i++){
+      io->enableInput(accelerationSensors[i]);
+    }
+    const DeviceList<ForceSensor>& forceSensors = robot->devices();
+    for(int i=0; i < forceSensors.size(); i++){
+      io->enableInput(forceSensors[i]);
+    }
+
+    std::string pdgainsSimFileName;
+    int shm_key = 5555;
+    bool servoOff = false;
+
+    std::vector<std::string> options = io->options();
+    for(size_t i=0;i<options.size();i++){
+      std::string option = "pdGainsSimFileName:";
+      if (options[i].size() >= option.size() &&
+          std::equal(std::begin(option), std::end(option), std::begin(options[i]))) {
+        pdgainsSimFileName = options[i].substr(option.size());
+        continue;
+      }
+      option = "shm_key:";
+      if (options[i].size() >= option.size() &&
+          std::equal(std::begin(option), std::end(option), std::begin(options[i]))) {
+        shm_key = std::stoi(options[i].substr(option.size()));
+        continue;
+      }
+      option = "servoOff:";
+      if (options[i].size() >= option.size() &&
+          std::equal(std::begin(option), std::end(option), std::begin(options[i]))) {
+        std::string value = options[i].substr(option.size());
+        if (value == "True" ||
+            value == "true" ||
+            value == "TRUE" ||
+            value == "1") {
+          servoOff = true;
+        }
+        continue;
+      }
+    }
+
+    readGainFile(pdgainsSimFileName);
+
+    for(int i=0; i < robot->numJoints(); ++i){
+      Link* joint = robot->joint(i);
+      joint->setActuationMode(Link::JOINT_TORQUE);
+      io->enableOutput(joint);
+      io->enableInput(joint, JOINT_DISPLACEMENT | JOINT_VELOCITY);
+    }
+
+    this->initialize_shm(shm_key, servoOff);
+    return true;
+  }
+
+  virtual bool control() override
+  {
+    read_shm_and_control();
+    write_shm();
+    return true;
+  }
+};
+
+CNOID_IMPLEMENT_SIMPLE_CONTROLLER_FACTORY(BridgeShmController)

--- a/hrpsys_choreonoid/src/ClockPublisherItem.cpp
+++ b/hrpsys_choreonoid/src/ClockPublisherItem.cpp
@@ -1,0 +1,71 @@
+#include "ClockPublisherItem.h"
+#include <QCoreApplication>
+#include <cnoid/ItemManager>
+#include <rosgraph_msgs/Clock.h>
+
+namespace cnoid {
+
+  void ClockPublisherItem::initializeClass(ExtensionManager* ext)
+  {
+    ext->itemManager().registerClass<ClockPublisherItem>("ClockPublisherItem");
+  }
+
+  ClockPublisherItem::ClockPublisherItem(){
+    if(!ros::isInitialized()){
+      QStringList argv_list = QCoreApplication::arguments();
+      int argc = argv_list.size();
+      char* argv[argc];
+      //なぜかわからないがargv_list.at(i).toUtf8().data()のポインタをそのままargvに入れるとros::initがうまく解釈してくれない.
+      for(size_t i=0;i<argv_list.size();i++){
+        char* data = argv_list.at(i).toUtf8().data();
+        size_t dataSize = 0;
+        for(size_t j=0;;j++){
+          if(data[j] == '\0'){
+            dataSize = j;
+            break;
+          }
+        }
+        argv[i] = (char *)malloc(sizeof(char) * dataSize+1);
+        for(size_t j=0;j<dataSize;j++){
+          argv[i][j] = data[j];
+        }
+        argv[i][dataSize] = '\0';
+      }
+      ros::init(argc,argv,"choreonoid");
+      for(size_t i=0;i<argc;i++){
+        free(argv[i]);
+      }
+    }
+    this->clockPublisher_ = ros::NodeHandle().advertise<rosgraph_msgs::Clock>("/clock", 1);
+    SimulationBar::instance()->sigSimulationAboutToStart().connect([&](SimulatorItem* simulatorItem){onSimulationAboutToStart(simulatorItem);});
+  }
+
+  void ClockPublisherItem::onSimulationAboutToStart(SimulatorItem* simulatorItem)
+  {
+    this->currentSimulatorItem_ = simulatorItem;
+    this->currentSimulatorItemConnections_.add(
+        simulatorItem->sigSimulationStarted().connect(
+            [&](){ onSimulationStarted(); }));
+  }
+
+  void ClockPublisherItem::onSimulationStarted()
+  {
+    this->currentSimulatorItem_->addPreDynamicsFunction([&](){ onSimulationStep(); });
+  }
+
+  void ClockPublisherItem::onSimulationStep()
+  {
+    double timestep = this->currentSimulatorItem_->worldTimeStep();
+    int frame = this->currentSimulatorItem_->simulationFrame();
+
+    unsigned long timestep_nsec = timestep * 1000000000;
+    unsigned long long time_nsec = frame * timestep_nsec;
+
+    // Publish clock
+    rosgraph_msgs::Clock msg;
+    msg.clock.sec = time_nsec / 1000000000;
+    msg.clock.nsec = time_nsec - msg.clock.sec * 1000000000;
+    this->clockPublisher_.publish(msg);
+  }
+}
+

--- a/hrpsys_choreonoid/src/ClockPublisherItem.h
+++ b/hrpsys_choreonoid/src/ClockPublisherItem.h
@@ -1,0 +1,32 @@
+#ifndef CLOCKPUBLISHER_ITEM_H
+#define CLOCKPUBLISHER_ITEM_H
+
+#include <cnoid/Item>
+#include <ros/ros.h>
+#include <cnoid/SimulationBar>
+#include <cnoid/SimulatorItem>
+#include <cnoid/ConnectionSet>
+
+namespace cnoid {
+
+  class ClockPublisherItem : public Item
+  {
+  public:
+    static void initializeClass(ExtensionManager* ext);
+
+    ClockPublisherItem();
+
+  protected:
+    void onSimulationAboutToStart(SimulatorItem* simulatorItem);
+    void onSimulationStarted();
+    void onSimulationStep();
+
+    ros::Publisher clockPublisher_;
+    SimulatorItem* currentSimulatorItem_;
+    ScopedConnectionSet currentSimulatorItemConnections_;
+  };
+
+  typedef ref_ptr<ClockPublisherItem> ClockPublisherItemPtr;
+}
+
+#endif

--- a/hrpsys_choreonoid/src/ClockShmItem.cpp
+++ b/hrpsys_choreonoid/src/ClockShmItem.cpp
@@ -1,0 +1,55 @@
+#include "ClockShmItem.h"
+#include <QCoreApplication>
+#include <cnoid/ItemManager>
+#include <cnoid/MessageView>
+#include <sys/shm.h>
+
+namespace cnoid {
+
+  void ClockShmItem::initializeClass(ExtensionManager* ext)
+  {
+    ext->itemManager().registerClass<ClockShmItem>("ClockShmItem");
+  }
+
+  ClockShmItem::ClockShmItem(){
+    SimulationBar::instance()->sigSimulationAboutToStart().connect([&](SimulatorItem* simulatorItem){onSimulationAboutToStart(simulatorItem);});
+
+    int shm_id = shmget(969, sizeof(struct timeval), 0666|IPC_CREAT);
+    if(shm_id == -1) {
+      MessageView::instance()->cout() << "\e[0;31m" << "[ClockShmItem] shmget failed"  << "\e[0m" << std::endl;
+      return;
+    }
+    this->c_shm = (struct timeval *)shmat(shm_id, (void *)0, 0);
+    if(this->c_shm == (void*)-1) {
+      MessageView::instance()->cout() << "\e[0;31m" << "[ClockShmItem] shmat failed"  << "\e[0m" << std::endl;
+    }
+  }
+
+  void ClockShmItem::onSimulationAboutToStart(SimulatorItem* simulatorItem)
+  {
+    this->currentSimulatorItem_ = simulatorItem;
+    this->currentSimulatorItemConnections_.add(
+        simulatorItem->sigSimulationStarted().connect(
+            [&](){ onSimulationStarted(); }));
+  }
+
+  void ClockShmItem::onSimulationStarted()
+  {
+    this->currentSimulatorItem_->addPreDynamicsFunction([&](){ onSimulationStep(); });
+  }
+
+  void ClockShmItem::onSimulationStep()
+  {
+    if(!this->c_shm) return;
+
+    double timestep = this->currentSimulatorItem_->worldTimeStep();
+    int frame = this->currentSimulatorItem_->simulationFrame();
+
+    unsigned long timestep_usec = timestep * 1000000;
+    unsigned long long time_usec = frame * timestep_usec;
+
+    c_shm->tv_sec = time_usec / 1000000;
+    c_shm->tv_usec = time_usec - c_shm->tv_sec * 1000000;
+  }
+}
+

--- a/hrpsys_choreonoid/src/ClockShmItem.h
+++ b/hrpsys_choreonoid/src/ClockShmItem.h
@@ -1,0 +1,32 @@
+#ifndef CLOCKSHM_ITEM_H
+#define CLOCKSHM_ITEM_H
+
+#include <cnoid/Item>
+#include <cnoid/SimulationBar>
+#include <cnoid/SimulatorItem>
+#include <cnoid/ConnectionSet>
+#include <sys/time.h>
+
+namespace cnoid {
+
+  class ClockShmItem : public Item
+  {
+  public:
+    static void initializeClass(ExtensionManager* ext);
+
+    ClockShmItem();
+
+  protected:
+    void onSimulationAboutToStart(SimulatorItem* simulatorItem);
+    void onSimulationStarted();
+    void onSimulationStep();
+
+    SimulatorItem* currentSimulatorItem_;
+    ScopedConnectionSet currentSimulatorItemConnections_;
+    struct timeval* c_shm;
+  };
+
+  typedef ref_ptr<ClockShmItem> ClockShmItemPtr;
+}
+
+#endif

--- a/hrpsys_choreonoid/src/CnoidHrpsysChoreonoidPlugin.cpp
+++ b/hrpsys_choreonoid/src/CnoidHrpsysChoreonoidPlugin.cpp
@@ -1,0 +1,32 @@
+#include <cnoid/Plugin>
+#include <cnoid/MenuManager>
+#include <cnoid/MessageView>
+
+#include "ClockPublisherItem.h"
+#include "ClockShmItem.h"
+#include "DepthCameraPublisherItem.h"
+#include "OdometryPublisherItem.h"
+
+using namespace cnoid;
+
+class HrpsysChoreonoidPlugin : public Plugin
+{
+public:
+
+    HrpsysChoreonoidPlugin() : Plugin("HrpsysChoreonoid")
+    {
+      require("Body");
+    }
+
+    virtual bool initialize() override
+    {
+      ClockPublisherItem::initializeClass(this);
+      ClockShmItem::initializeClass(this);
+      DepthCameraPublisherItem::initializeClass(this);
+      OdometryPublisherItem::initializeClass(this);
+      return true;
+    }
+
+};
+
+CNOID_IMPLEMENT_PLUGIN_ENTRY(HrpsysChoreonoidPlugin)

--- a/hrpsys_choreonoid/src/DepthCameraPublisherItem.cpp
+++ b/hrpsys_choreonoid/src/DepthCameraPublisherItem.cpp
@@ -1,0 +1,268 @@
+#include "DepthCameraPublisherItem.h"
+#include <QCoreApplication>
+#include <cnoid/ItemManager>
+#include <cnoid/Archive>
+#include <sensor_msgs/Image.h>
+#include <sensor_msgs/CameraInfo.h>
+#include <sensor_msgs/image_encodings.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <limits>
+
+namespace cnoid {
+
+  void DepthCameraPublisherItem::initializeClass(ExtensionManager* ext)
+  {
+    ext->itemManager().registerClass<DepthCameraPublisherItem>("DepthCameraPublisherItem");
+  }
+
+  DepthCameraPublisherItem::DepthCameraPublisherItem(){
+    if(!ros::isInitialized()){
+      QStringList argv_list = QCoreApplication::arguments();
+      int argc = argv_list.size();
+      char* argv[argc];
+      //なぜかわからないがargv_list.at(i).toUtf8().data()のポインタをそのままargvに入れるとros::initがうまく解釈してくれない.
+      for(size_t i=0;i<argv_list.size();i++){
+        char* data = argv_list.at(i).toUtf8().data();
+        size_t dataSize = 0;
+        for(size_t j=0;;j++){
+          if(data[j] == '\0'){
+            dataSize = j;
+            break;
+          }
+        }
+        argv[i] = (char *)malloc(sizeof(char) * dataSize+1);
+        for(size_t j=0;j<dataSize;j++){
+          argv[i][j] = data[j];
+        }
+        argv[i][dataSize] = '\0';
+      }
+      ros::init(argc,argv,"choreonoid");
+      for(size_t i=0;i<argc;i++){
+        free(argv[i]);
+      }
+    }
+
+  }
+
+  void DepthCameraPublisherItem::setupROS() {
+    if(this->setupROSDone_) return;
+    this->setupROSDone_ = true;
+
+    ros::NodeHandle nh;
+
+    image_transport::ImageTransport it(nh);
+
+    if(this->publishColor_){
+      std::string topicName;
+      if(this->imageTopicName_!="") topicName = this->imageTopicName_;
+      else topicName = this->cameraName_+"/color/image_raw";
+      this->imagePub_ = it.advertise(topicName, 1);
+
+      std::string infoName;
+      if(this->cameraInfoTopicName_!="") infoName = this->cameraInfoTopicName_;
+      else infoName = this->cameraName_+"/color/camera_info";
+      this->infoPub_ = nh.advertise<sensor_msgs::CameraInfo>(infoName, 1);
+    }
+
+    if(this->publishDepth_){
+      std::string depthTopicName;
+      if(this->depthImageTopicName_!="") depthTopicName = this->depthImageTopicName_;
+      else depthTopicName = this->cameraName_+"/depth/image_raw";
+      this->depthImagePub_ = it.advertise(depthTopicName, 1);
+
+      std::string depthInfoName;
+      if(this->depthCameraInfoTopicName_!="") depthInfoName = this->depthCameraInfoTopicName_;
+      else depthInfoName = this->cameraName_+"/depth/camera_info";
+      this->depthInfoPub_ = nh.advertise<sensor_msgs::CameraInfo>(depthInfoName, 1);
+    }
+
+    if(this->publishPointCloud_){
+      std::string pointTopicName;
+      if(this->pointCloudTopicName_!="") pointTopicName = this->pointCloudTopicName_;
+      else pointTopicName = this->cameraName_+"/depth_registered/points";
+      this->pointCloudPub_ = nh.advertise<sensor_msgs::PointCloud2>(pointTopicName, 1);
+    }
+  }
+
+  bool DepthCameraPublisherItem::initialize(ControllerIO* io) {
+    this->io_ = io;
+    this->timeStep_ = io->worldTimeStep();
+
+    setupROS(); // コンストラクタやcallLaterだとname()やrestore()が未完了
+
+    return true;
+  }
+
+  bool DepthCameraPublisherItem::start() {
+    this->sensor_ = this->io_->body()->findDevice<cnoid::RangeCamera>(this->cameraName_);
+    if (this->sensor_) {
+      this->sensor_->sigStateChanged().connect(boost::bind(&DepthCameraPublisherItem::updateVisionSensor, this));
+      return true;
+    }else{
+      this->io_->os() << "\e[0;31m" << "[DepthCameraPublisherItem] camera [" << this->cameraName_ << "] not found"  << "\e[0m" << std::endl;
+      return false;
+    }
+  }
+
+  void DepthCameraPublisherItem::updateVisionSensor() {
+    std_msgs::Header header;
+    header.stamp.fromSec(std::max(0.0, this->io_->currentTime() - this->sensor_->delay()));
+    if(this->frameId_.size()!=0) header.frame_id = this->frameId_;
+    else header.frame_id = this->sensor_->name();
+
+    sensor_msgs::CameraInfo info;
+    {
+      info.header = header;
+      info.width  = this->sensor_->image().width();
+      info.height = this->sensor_->image().height();
+      info.distortion_model = "plumb_bob";
+      info.K[0] = std::min(info.width, info.height) / 2 / tan(this->sensor_->fieldOfView()/2);
+      info.K[2] = (this->sensor_->image().width()-1)/2.0;
+      info.K[4] = info.K[0];
+      info.K[5] = (this->sensor_->image().height()-1)/2.0;
+      info.K[8] = 1;
+      info.P[0] = info.K[0];
+      info.P[2] = info.K[2];
+      info.P[5] = info.K[4];
+      info.P[6] = info.K[5];
+      info.P[10] = 1;
+      info.R[0] = info.R[4] = info.R[8] = 1;
+    }
+
+    if(this->publishColor_){
+      sensor_msgs::Image vision;
+      {
+        vision.header = header;
+        vision.height = this->sensor_->image().height();
+        vision.width = this->sensor_->image().width();
+        if (this->sensor_->image().numComponents() == 3)
+          vision.encoding = sensor_msgs::image_encodings::RGB8;
+        else if (this->sensor_->image().numComponents() == 1)
+          vision.encoding = sensor_msgs::image_encodings::MONO8;
+        else {
+          ROS_WARN("unsupported image component number: %i", this->sensor_->image().numComponents());
+        }
+        vision.is_bigendian = 0;
+        vision.step = this->sensor_->image().width() * this->sensor_->image().numComponents();
+        vision.data.resize(vision.step * vision.height);
+        std::memcpy(&(vision.data[0]), &(this->sensor_->image().pixels()[0]), vision.step * vision.height);
+      }
+      this->imagePub_.publish(vision);
+
+      this->infoPub_.publish(info);
+    }
+
+    if(this->publishDepth_){
+      sensor_msgs::Image depth;
+      {
+        depth.header = header;
+        depth.width = this->sensor_->resolutionX();
+        depth.height = this->sensor_->resolutionY();
+        depth.encoding = sensor_msgs::image_encodings::TYPE_32FC1;
+        depth.step  = depth.width * 4;
+        depth.data.resize(depth.step * depth.height);
+        float* dst_ptr = (float *)depth.data.data();
+        const std::vector<Vector3f>& points = this->sensor_->constPoints();
+        for(int i = 0; i < points.size(); i++) {
+          // OpenHRP3 camera, front direction is -Z axis, ROS camera is Z axis
+          // http://www.openrtp.jp/openhrp3/jp/create_model.html
+          float z = points[i].z() * -1;
+          if( z < this->minDistance_ ) z = -std::numeric_limits<float>::infinity(); // Detections that are too close to the sensor to quantify shall be represented by -Inf. https://www.ros.org/reps/rep-0117.html
+          *dst_ptr++ = z;
+        }
+      }
+      this->depthImagePub_.publish(depth);
+
+      this->depthInfoPub_.publish(info);
+    }
+
+    if(this->publishPointCloud_){
+      sensor_msgs::PointCloud2 pointcloud;
+      {
+        pointcloud.header = header;
+        pointcloud.width = this->sensor_->resolutionX();
+        pointcloud.height = this->sensor_->resolutionY();
+        pointcloud.is_bigendian = false;
+        pointcloud.is_dense = true;
+        if (this->sensor_->imageType() == cnoid::Camera::COLOR_IMAGE) {
+          pointcloud.fields.resize(4);
+          pointcloud.fields[3].name = "rgb";
+          pointcloud.fields[3].offset = 12;
+          pointcloud.fields[3].count = 1;
+          pointcloud.fields[3].datatype = sensor_msgs::PointField::FLOAT32;
+          pointcloud.point_step = 16;
+        } else {
+          pointcloud.fields.resize(3);
+          pointcloud.point_step = 12;
+        }
+        pointcloud.fields[0].name = "x";
+        pointcloud.fields[0].offset = 0;
+        pointcloud.fields[0].datatype = sensor_msgs::PointField::FLOAT32;
+        pointcloud.fields[0].count = 1;
+        pointcloud.fields[1].name = "y";
+        pointcloud.fields[1].offset = 4;
+        pointcloud.fields[1].datatype = sensor_msgs::PointField::FLOAT32;
+        pointcloud.fields[1].count = 1;
+        pointcloud.fields[2].name = "z";
+        pointcloud.fields[2].offset = 8;
+        pointcloud.fields[2].datatype = sensor_msgs::PointField::FLOAT32;
+        pointcloud.fields[2].count = 1;
+        pointcloud.row_step = pointcloud.point_step * pointcloud.width;
+        const std::vector<Vector3f>& points = this->sensor_->constPoints();
+        const unsigned char* pixels = this->sensor_->constImage().pixels();
+        pointcloud.data.resize(points.size() * pointcloud.point_step);
+        unsigned char* dst = (unsigned char*)&(pointcloud.data[0]);
+        for (size_t j = 0; j < points.size(); ++j) {
+          // OpenHRP3 camera, front direction is -Z axis, ROS camera is Z axis
+          // http://www.openrtp.jp/openhrp3/jp/create_model.html
+          float x = points[j].x();
+          float y = - points[j].y();
+          float z = - points[j].z();
+          if( z < this->minDistance_ ) z = -std::numeric_limits<float>::infinity(); // Detections that are too close to the sensor to quantify shall be represented by -Inf. https://www.ros.org/reps/rep-0117.html
+          std::memcpy(&dst[0], &x, 4);
+          std::memcpy(&dst[4], &y, 4);
+          std::memcpy(&dst[8], &z, 4);
+          if (this->sensor_->imageType() == cnoid::Camera::COLOR_IMAGE) {
+            dst[14] = *pixels++;
+            dst[13] = *pixels++;
+            dst[12] = *pixels++;
+            dst[15] = 0;
+          }
+          dst += pointcloud.point_step;
+        }
+      }
+      this->pointCloudPub_.publish(pointcloud);
+    }
+  }
+
+  bool DepthCameraPublisherItem::store(Archive& archive) {
+    archive.write("cameraName", this->cameraName_);
+    archive.write("imageTopicName", this->imageTopicName_);
+    archive.write("cameraInfoTopicName", this->cameraInfoTopicName_);
+    archive.write("depthImageTopicName", this->depthImageTopicName_);
+    archive.write("depthCameraInfoTopicName", this->depthCameraInfoTopicName_);
+    archive.write("pointCloudTopicName", this->pointCloudTopicName_);
+    archive.write("frameId", this->frameId_);
+    archive.write("minDistance", this->minDistance_);
+    archive.write("publishColor", this->publishColor_);
+    archive.write("publishDepth", this->publishDepth_);
+    archive.write("publishPointCloud", this->publishPointCloud_);
+    return true;
+  }
+
+  bool DepthCameraPublisherItem::restore(const Archive& archive) {
+    archive.read("cameraName", this->cameraName_);
+    archive.read("imageTopicName", this->imageTopicName_);
+    archive.read("cameraInfoTopicName", this->cameraInfoTopicName_);
+    archive.read("depthImageTopicName", this->depthImageTopicName_);
+    archive.read("depthCameraInfoTopicName", this->depthCameraInfoTopicName_);
+    archive.read("pointCloudTopicName", this->pointCloudTopicName_);
+    archive.read("frameId", this->frameId_);
+    archive.read("minDistance", this->minDistance_);
+    archive.read("publishColor", this->publishColor_);
+    archive.read("publishDepth", this->publishDepth_);
+    archive.read("publishPointCloud", this->publishPointCloud_);
+    return true;
+  }
+
+}

--- a/hrpsys_choreonoid/src/DepthCameraPublisherItem.h
+++ b/hrpsys_choreonoid/src/DepthCameraPublisherItem.h
@@ -1,0 +1,60 @@
+#ifndef CNOIDROSEXTPLUGIN_DEPTHCAMERAPUBLISHER_ITEM_H
+#define CNOIDROSEXTPLUGIN_DEPTHCAMERAPUBLISHER_ITEM_H
+
+#include <cnoid/ControllerItem>
+#include <cnoid/RangeCamera>
+#include <ros/ros.h>
+#include <image_transport/image_transport.h>
+
+namespace cnoid {
+
+  class DepthCameraPublisherItem : public ControllerItem
+  {
+  public:
+    static void initializeClass(ExtensionManager* ext);
+
+    DepthCameraPublisherItem();
+
+    virtual bool initialize(ControllerIO* io) override;
+    virtual bool start() override;
+
+    virtual double timeStep() const override { return timeStep_;};
+    virtual void input() override {}
+    virtual bool control() override { return true;}
+    virtual void output() override {}
+    virtual void stop() override {}
+
+    virtual bool store(Archive& archive) override;
+    virtual bool restore(const Archive& archive) override;
+
+  protected:
+    void setupROS(); bool setupROSDone_ = false;
+    void updateVisionSensor();
+
+    image_transport::Publisher imagePub_;
+    ros::Publisher infoPub_;
+    image_transport::Publisher depthImagePub_;
+    ros::Publisher depthInfoPub_;
+    ros::Publisher pointCloudPub_;
+
+    std::string cameraName_;
+    std::string imageTopicName_;
+    std::string cameraInfoTopicName_;
+    std::string depthImageTopicName_;
+    std::string depthCameraInfoTopicName_;
+    std::string pointCloudTopicName_;
+    std::string frameId_;
+    double minDistance_ = 0.0;
+    bool publishColor_ = true;
+    bool publishDepth_ = true;
+    bool publishPointCloud_ = true;
+
+    cnoid::ControllerIO* io_;
+    cnoid::RangeCameraPtr sensor_;
+    double timeStep_;
+  };
+
+  typedef ref_ptr<DepthCameraPublisherItem> DepthCameraPublisherItemPtr;
+}
+
+#endif

--- a/hrpsys_choreonoid/src/OdometryPublisherItem.cpp
+++ b/hrpsys_choreonoid/src/OdometryPublisherItem.cpp
@@ -1,0 +1,166 @@
+#include "OdometryPublisherItem.h"
+#include <QCoreApplication>
+#include <cnoid/ItemManager>
+#include <cnoid/Archive>
+#include <nav_msgs/Odometry.h>
+
+namespace cnoid {
+
+  void OdometryPublisherItem::initializeClass(ExtensionManager* ext)
+  {
+    ext->itemManager().registerClass<OdometryPublisherItem>("OdometryPublisherItem");
+  }
+
+  OdometryPublisherItem::OdometryPublisherItem(){
+    if(!ros::isInitialized()){
+      QStringList argv_list = QCoreApplication::arguments();
+      int argc = argv_list.size();
+      char* argv[argc];
+      //なぜかわからないがargv_list.at(i).toUtf8().data()のポインタをそのままargvに入れるとros::initがうまく解釈してくれない.
+      for(size_t i=0;i<argv_list.size();i++){
+        char* data = argv_list.at(i).toUtf8().data();
+        size_t dataSize = 0;
+        for(size_t j=0;;j++){
+          if(data[j] == '\0'){
+            dataSize = j;
+            break;
+          }
+        }
+        argv[i] = (char *)malloc(sizeof(char) * dataSize+1);
+        for(size_t j=0;j<dataSize;j++){
+          argv[i][j] = data[j];
+        }
+        argv[i][dataSize] = '\0';
+      }
+      ros::init(argc,argv,"choreonoid");
+      for(size_t i=0;i<argc;i++){
+        free(argv[i]);
+      }
+    }
+  }
+
+  void OdometryPublisherItem::setupROS() {
+    if(this->setupROSDone_) return;
+    this->setupROSDone_ = true;
+
+    ros::NodeHandle nh;
+
+    std::string topicName;
+    if(this->odometryTopicName_!="") topicName = this->odometryTopicName_;
+    else topicName = this->targetName_+"/odom";
+    this->pub_ = nh.advertise<nav_msgs::Odometry>(topicName, 1);
+  }
+
+  bool OdometryPublisherItem::initialize(ControllerIO* io) {
+    this->io_ = io;
+    this->timeStep_ = io->worldTimeStep();
+
+    setupROS(); // コンストラクタやcallLaterだとname()やrestore()が未完了
+
+    return true;
+  }
+
+  bool OdometryPublisherItem::start() {
+    this->link_ = this->io_->body()->link(this->targetName_);
+    if(!link_) this->sensor_ = this->io_->body()->findDevice<cnoid::Camera>(this->targetName_);
+    if (this->link_ || this->sensor_) {
+      return true;
+    }else{
+      this->io_->os() << "\e[0;31m" << "[OdometryPublisherItem] camera [" << this->targetName_ << "] not found"  << "\e[0m" << std::endl;
+      return false;
+    }
+  }
+
+  bool OdometryPublisherItem::control() {
+    if(!this->link_ && !this->sensor_) return true;
+
+    if(this->timeStep_ < 1.0 / this->publishRate_){
+      this->time_ += this->timeStep_;
+      if(this->time_ < 1.0 / this->publishRate_) return true;
+      this->time_ -= 1.0 / this->publishRate_;
+    }
+
+    std_msgs::Header header;
+    header.stamp.fromSec(this->io_->currentTime());
+    if(this->frameId_.size()!=0) header.frame_id = this->frameId_;
+    else header.frame_id = "odom";
+
+    nav_msgs::Odometry odom;
+    {
+      odom.header = header;
+      if(this->childFrameId_.size()!=0) odom.child_frame_id = this->childFrameId_;
+      else odom.child_frame_id = this->targetName_;
+
+      cnoid::Position pose;
+      if(this->link_){
+        pose = this->link_->T();
+      }else{
+        pose = this->sensor_->link()->T() * this->sensor_->T_local();
+        // Rotate sensor->localR 180[deg] because OpenHRP3 camera -Z axis equals to ROS camera Z axis
+        // http://www.openrtp.jp/openhrp3/jp/create_model.html
+        pose.linear() = (pose.linear() * cnoid::AngleAxis(M_PI, cnoid::Vector3::UnitX())).eval();
+      }
+      odom.pose.pose.position.x = pose.translation()[0];
+      odom.pose.pose.position.y = pose.translation()[1];
+      odom.pose.pose.position.z = pose.translation()[2];
+      cnoid::Quaternion quat = cnoid::Quaternion(pose.linear());
+      odom.pose.pose.orientation.x = quat.x();
+      odom.pose.pose.orientation.y = quat.y();
+      odom.pose.pose.orientation.z = quat.z();
+      odom.pose.pose.orientation.w = quat.w();
+      for(int i=0;i<6;i++){
+        for(int j=0;j<6;j++){
+          if(i==j) odom.pose.covariance[i*6+j] = this->poseCovariance_;
+          else odom.pose.covariance[i*6+j] = 0.0;
+        }
+      }
+
+      cnoid::Vector6 twist;
+      twist.head<3>() = pose.linear().transpose() * (pose.translation() - this->prevPose_.translation()) / this->timeStep_;
+      cnoid::AngleAxis angleAxis = cnoid::AngleAxis(this->prevPose_.linear().transpose() * pose.linear());
+      twist.tail<3>() = angleAxis.angle()*angleAxis.axis() / this->timeStep_;
+      odom.twist.twist.linear.x = twist[0];
+      odom.twist.twist.linear.y = twist[1];
+      odom.twist.twist.linear.z = twist[2];
+      odom.twist.twist.angular.x = twist[3];
+      odom.twist.twist.angular.y = twist[4];
+      odom.twist.twist.angular.z = twist[5];
+      for(int i=0;i<6;i++){
+        for(int j=0;j<6;j++){
+          if(i==j) odom.twist.covariance[i*6+j] = this->twistCovariance_;
+          else odom.twist.covariance[i*6+j] = 0.0;
+        }
+      }
+
+      this->pub_.publish(odom);
+
+      this->prevPose_ = pose;
+    }
+
+    return true;
+  }
+
+  bool OdometryPublisherItem::store(Archive& archive) {
+    archive.write("targetName", this->targetName_);
+    archive.write("odometryTopicName", this->odometryTopicName_);
+    archive.write("frameId", this->frameId_);
+    archive.write("childFrameId", this->childFrameId_);
+    archive.write("poseCovariance", this->poseCovariance_);
+    archive.write("twistCovariance", this->twistCovariance_);
+    archive.write("publishRate", this->publishRate_);
+    return true;
+  }
+
+  bool OdometryPublisherItem::restore(const Archive& archive) {
+    archive.read("targetName", this->targetName_);
+    archive.read("odometryTopicName", this->odometryTopicName_);
+    archive.read("frameId", this->frameId_);
+    archive.read("childFrameId", this->childFrameId_);
+    archive.read("poseCovariance", this->poseCovariance_);
+    archive.read("twistCovariance", this->twistCovariance_);
+    archive.read("publishRate", this->publishRate_);
+    return true;
+  }
+
+}
+

--- a/hrpsys_choreonoid/src/OdometryPublisherItem.h
+++ b/hrpsys_choreonoid/src/OdometryPublisherItem.h
@@ -1,0 +1,54 @@
+#ifndef CNOIDROSEXTPLUGIN_ODOMETRYPUBLISHER_ITEM_H
+#define CNOIDROSEXTPLUGIN_ODOMETRYPUBLISHER_ITEM_H
+
+#include <cnoid/ControllerItem>
+#include <cnoid/Camera>
+#include <ros/ros.h>
+
+namespace cnoid {
+
+  class OdometryPublisherItem : public ControllerItem
+  {
+  public:
+    static void initializeClass(ExtensionManager* ext);
+
+    OdometryPublisherItem();
+
+    virtual bool initialize(ControllerIO* io) override;
+    virtual bool start() override;
+
+    virtual double timeStep() const override { return timeStep_;};
+    virtual void input() override {}
+    virtual bool control() override;
+    virtual void output() override {}
+    virtual void stop() override {}
+
+    virtual bool store(Archive& archive) override;
+    virtual bool restore(const Archive& archive) override;
+
+  protected:
+    void setupROS(); bool setupROSDone_ = false;
+
+    ros::Publisher pub_;
+
+    std::string targetName_;
+    std::string odometryTopicName_;
+    std::string frameId_;
+    std::string childFrameId_;
+    double poseCovariance_ = 0.0;
+    double twistCovariance_ = 0.0;
+    double publishRate_ = 100.0;
+
+    cnoid::ControllerIO* io_;
+    cnoid::CameraPtr sensor_;
+    cnoid::LinkPtr link_;
+    double timeStep_;
+    cnoid::Position prevPose_ = cnoid::Position::Identity();
+
+    double time_ = 0.0;
+  };
+
+  typedef ref_ptr<OdometryPublisherItem> OdometryPublisherItemPtr;
+}
+
+#endif

--- a/hrpsys_choreonoid/src/ShmTimePeriodicExecutionContext.cpp
+++ b/hrpsys_choreonoid/src/ShmTimePeriodicExecutionContext.cpp
@@ -1,0 +1,97 @@
+#include "ShmTimePeriodicExecutionContext.h"
+#include <rtm/ECFactory.h>
+#include <sys/shm.h>
+
+ShmTimePeriodicExecutionContext::ShmTimePeriodicExecutionContext()
+    : PeriodicExecutionContext()
+{
+}
+
+ShmTimePeriodicExecutionContext::~ShmTimePeriodicExecutionContext()
+{
+}
+
+int ShmTimePeriodicExecutionContext::svc(void)
+{
+  RTC_TRACE(("svc()"));
+  int count(0);
+
+  struct timeval * c_shm;
+
+  int shm_id = shmget(969, sizeof(struct timeval), 0666|IPC_CREAT);
+  if(shm_id == -1) {
+    std::cerr << "\e[0;31m" << "[ClockShmItem] shmget failed"  << "\e[0m" << std::endl;
+    exit(1);
+  }
+  c_shm = (struct timeval *)shmat(shm_id, (void *)0, 0);
+  if(c_shm == (void*)-1) {
+    std::cerr << "\e[0;31m" << "[ClockShmItem] shmat failed"  << "\e[0m" << std::endl;
+    exit(1);
+  }
+
+  coil::TimeValue prev_t(c_shm->tv_sec,c_shm->tv_usec);
+  std::vector<std::string> rtc_names;
+  do
+    {
+      m_worker.mutex_.lock();
+      while (!m_worker.running_)
+        {
+          m_worker.cond_.wait();
+        }
+
+      std::vector<double> processTimes(m_comps.size());
+      if (m_worker.running_)
+        {
+          for(int i=0;i<m_comps.size();i++){
+            coil::TimeValue before(c_shm->tv_sec,c_shm->tv_usec);
+            invoke_worker()(m_comps[i]);
+            coil::TimeValue after(c_shm->tv_sec,c_shm->tv_usec);
+            processTimes[i] = double(after - before);
+          }
+        }
+      m_worker.mutex_.unlock();
+      coil::TimeValue cur_t(c_shm->tv_sec,c_shm->tv_usec);
+      if((double)(cur_t - prev_t) < 0) prev_t = cur_t; //巻き戻り
+
+      if ((double)(cur_t - prev_t) > m_period){
+        if( m_comps.size() != rtc_names.size() ) {
+          rtc_names.resize(m_comps.size());
+          for(int i=0;i<m_comps.size();i++){
+            RTC::ComponentProfile_var profile = RTC::RTObject::_narrow(m_comps[i]._ref)->get_component_profile(); // get_component_profile() はポインタを返すので、呼び出し側で release するか、_var型変数で受ける必要がある. get_component_profile() は時間がかかるので、毎周期呼んではいけない
+            rtc_names[i] = profile->instance_name;
+          }
+        }
+
+        std::cerr<<"[ShmTimeEC] Timeover: processing time = "<<(double)(cur_t - prev_t)<<"[s]"<<std::endl;
+        for(int i=0;i<m_comps.size();i++){
+          std::cerr << rtc_names[i] <<"("<<processTimes[i]<<"), ";
+        }
+        std::cerr << std::endl;
+      }
+
+      // ROS::Timeは/clockが届いたときにしか変化しない. /clockの周期と制御周期が近い場合、単純なcoil::sleep(m_period - (t1 - t0))では誤差が大きい
+      while (!m_nowait && m_period > (cur_t - prev_t))
+        {
+          coil::sleep((coil::TimeValue)(double(m_period) / 100));
+          cur_t = coil::TimeValue(c_shm->tv_sec,c_shm->tv_usec);
+          if((double)(cur_t - prev_t) < 0) prev_t = cur_t; //巻き戻り
+        }
+
+      while (prev_t < cur_t) prev_t = prev_t + m_period;
+      ++count;
+    } while (m_svc);
+
+  return 0;
+}
+
+extern "C"
+{
+    void ShmTimePeriodicExecutionContextInit(RTC::Manager* manager)
+    {
+        manager->registerECFactory("ShmTimePeriodicExecutionContext",
+                                   RTC::ECCreate<ShmTimePeriodicExecutionContext>,
+                                   RTC::ECDelete<ShmTimePeriodicExecutionContext>);
+        std::cerr << "ShmTimePeriodicExecutionContext is registered" << std::endl;
+    }
+};
+ 

--- a/hrpsys_choreonoid/src/ShmTimePeriodicExecutionContext.h
+++ b/hrpsys_choreonoid/src/ShmTimePeriodicExecutionContext.h
@@ -1,0 +1,23 @@
+#ifndef SHMTIMEPERIODICEXECUTIONCONTEXT_H
+#define SHMTIMEPERIODICEXECUTIONCONTEXT_H
+
+#include <rtm/RTC.h>
+#include <rtm/Manager.h>
+
+#include <rtm/PeriodicExecutionContext.h>
+
+
+class ShmTimePeriodicExecutionContext : public virtual RTC::PeriodicExecutionContext
+{
+public:
+    ShmTimePeriodicExecutionContext();
+    virtual ~ShmTimePeriodicExecutionContext(void);
+    virtual int svc(void);
+};
+
+extern "C"
+{
+  void ShmTimePeriodicExecutionContextInit(RTC::Manager* manager);
+};
+
+#endif

--- a/hrpsys_choreonoid_tutorials/CMakeLists.txt
+++ b/hrpsys_choreonoid_tutorials/CMakeLists.txt
@@ -4,6 +4,8 @@ project(hrpsys_choreonoid_tutorials)
 find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge euscollada rostest rospy
   euslisp xacro control_msgs roseus hrpsys_ros_bridge_tutorials jvrc_models hrpsys_choreonoid)
 
+find_package(choreonoid)
+
 include(FindPkgConfig)
 pkg_check_modules(openhrp3 REQUIRED openhrp3.1)
 set(OPENHRP_SAMPLE_DIR ${openhrp3_PREFIX}/share/OpenHRP-3.1/sample)
@@ -173,6 +175,7 @@ configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_RH_FLAT.cnoid.in ${PROJECT
 configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_LOAD_OBJ.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_LOAD_OBJ.cnoid @ONLY)
 configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_LOAD_OBJ_NW.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_LOAD_OBJ_NW.cnoid @ONLY)
 configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_RH_LOAD_OBJ.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_RH_LOAD_OBJ.cnoid @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_SHM_LOAD_OBJ.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_SHM_LOAD_OBJ.cnoid @ONLY)
 
 configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_TUTORIALS.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_TUTORIALS.cnoid @ONLY)
 configure_file(${PROJECT_SOURCE_DIR}/config/JAXON_RED_HILLS.cnoid.in ${PROJECT_SOURCE_DIR}/config/JAXON_RED_HILLS.cnoid @ONLY)
@@ -206,3 +209,4 @@ endif()
 configure_file(${PROJECT_SOURCE_DIR}/config/flat.yaml.in ${PROJECT_SOURCE_DIR}/config/flat.yaml @ONLY)
 configure_file(${PROJECT_SOURCE_DIR}/config/soccer.yaml.in ${PROJECT_SOURCE_DIR}/config/soccer.yaml @ONLY)
 configure_file(${PROJECT_SOURCE_DIR}/config/footsal.yaml.in ${PROJECT_SOURCE_DIR}/config/footsal.yaml @ONLY)
+configure_file(${PROJECT_SOURCE_DIR}/config/floor.yaml.in ${PROJECT_SOURCE_DIR}/config/floor.yaml @ONLY)

--- a/hrpsys_choreonoid_tutorials/config/JAXON_RED_SHM_LOAD_OBJ.cnoid.in
+++ b/hrpsys_choreonoid_tutorials/config/JAXON_RED_SHM_LOAD_OBJ.cnoid.in
@@ -1,0 +1,437 @@
+items: 
+  id: 0
+  name: "Root"
+  plugin: Base
+  class: RootItem
+  children: 
+    - 
+      id: 1
+      name: "World"
+      plugin: Body
+      class: WorldItem
+      data: 
+        collisionDetection: false
+        collisionDetector: AISTCollisionDetector
+      children: 
+        -
+          id: 10
+          name: "ClockPublisher"
+          plugin: HrpsysChoreonoid
+          class: ClockPublisherItem
+        -
+          id: 11
+          name: "ClockShm"
+          plugin: HrpsysChoreonoid
+          class: ClockShmItem
+        - 
+          id: 2
+          name: "JAXON_RED"
+          plugin: Body
+          class: BodyItem
+          data: 
+            modelFile: "../../jvrc_models/JAXON_JVRC/JAXON_JVRCmain_hrpsys_bush.wrl"
+            format: CHOREONOID-BODY
+            currentBaseLink: "WAIST"
+            rootPosition: [ 0.0, 0.0, 1.0185 ]
+            rootAttitude: [ 
+              0, -1, 0, 
+              1, 0, 0, 
+              0, 0, 1 ]
+            jointPositions: [ 
+               0.000054, -0.003093, -0.262419,  0.681091, -0.418672,  0.003093,  0.000054, -0.003093, -0.262401,  0.681084, 
+              -0.418684,  0.003093,  0.000000,  0.000000,  0.000000,  0.000000,  0.450000,  0.000000,  0.523599, -0.349066,
+              -0.087266, -1.396263,  0.000000,  0.000000, -0.349066,  0.000000,  0.523599,  0.349066,  0.087266, -1.396263, 
+               0.000000,  0.000000, -0.349066,  0.000000,  0.000000,  0.000000,  0.000000,  0.000000 ]
+            initialRootPosition: [ 0.0, 0.0, 1.0185 ]
+            initialRootAttitude: [ 
+              0, -1, 0, 
+              1, 0, 0, 
+              0, 0, 1 ]
+            initialJointPositions: [ 
+               0.000054, -0.003093, -0.262419,  0.681091, -0.418672,  0.003093,  0.000054, -0.003093, -0.262401,  0.681084, 
+              -0.418684,  0.003093,  0.000000,  0.000000,  0.000000,  0.000000,  0.450000,  0.000000,  0.523599, -0.349066,
+              -0.087266, -1.396263,  0.000000,  0.000000, -0.349066,  0.000000,  0.523599,  0.349066,  0.087266, -1.396263, 
+               0.000000,  0.000000, -0.349066,  0.000000,  0.000000,  0.000000,  0.000000,  0.000000,  0.000000 ]
+            zmp: [ 0, 0, 0 ]
+            collisionDetection: true
+            selfCollisionDetection: false
+            isEditable: true
+          children: 
+            - 
+              id: 3
+              name: "SimpleController"
+              plugin: SimpleController
+              class: SimpleControllerItem
+              data: 
+                isNoDelayMode: true # 制御が1周期遅れるかどうか. ゲインが高いときは、trueにしないと発散する
+                controller: "BridgeShmController"
+                reloading: true
+                inputLinkPositions: false
+                controllerOptions: "pdGainsSimFileName:@PROJECT_SOURCE_DIR@/models/JAXON_JVRC.PDgains_sim.dat"
+        - 
+          id: 4
+          name: "AISTSimulator"
+          plugin: Body
+          class: AISTSimulatorItem
+          data: 
+            realtimeSync: true
+            fasterThanRealtime: false
+            recording: full
+            timeRangeMode: TimeBar range
+            onlyActiveControlPeriod: true
+            timeLength: 12000
+            allLinkPositionOutputMode: false
+            deviceStateOutput: true
+            controllerThreads: false # choreonoid1.7では、falseにしないとControllerItemのisNoDelayMode: trueが無効になる
+            recordCollisionData: false
+            dynamicsMode: Forward dynamics
+            integrationMode: Runge Kutta
+            gravity: [ 0, 0, -9.80665 ]
+            staticFriction: 1
+            slipFriction: 1
+            cullingThresh: 0.005
+            contactCullingDepth: 0.03
+            errorCriterion: 0.001
+            maxNumIterations: 1000
+            contactCorrectionDepth: 0.0001
+            contactCorrectionVelocityRatio: 1
+            kinematicWalking: false
+            2Dmode: false
+          children: 
+            - 
+              id: 5
+              name: "GLVisionSimulator"
+              plugin: Body
+              class: GLVisionSimulatorItem
+              data: 
+                enabled: true
+                targetBodies: [ JAXON_RED ]
+                targetSensors: [ HEAD_LEFT_CAMERA ]
+                maxFrameRate: 1000
+                maxLatency: 1
+                recordVisionData: false
+                useThread: true
+                useThreadsForSensors: true
+                bestEffort: false
+                allSceneObjects: false
+                rangeSensorPrecisionRatio: 2
+                depthError: 0
+                enableHeadLight: true
+                enableAdditionalLights: true
+            - 
+              id: 6
+              name: "GLVisionSimulator"
+              plugin: Body
+              class: GLVisionSimulatorItem
+              data: 
+                enabled: true
+                targetBodies: [ JAXON_RED ]
+                targetSensors: [ HEAD_RIGHT_CAMERA ]
+                maxFrameRate: 1000
+                maxLatency: 1
+                recordVisionData: false
+                useThread: true
+                useThreadsForSensors: true
+                bestEffort: false
+                allSceneObjects: false
+                rangeSensorPrecisionRatio: 2
+                depthError: 0
+                enableHeadLight: true
+                enableAdditionalLights: true
+            - 
+              id: 7
+              name: "GLVisionSimulator"
+              plugin: Body
+              class: GLVisionSimulatorItem
+              data: 
+                enabled: true
+                targetBodies: [ JAXON_RED ]
+                targetSensors: [ HEAD_RANGE ]
+                maxFrameRate: 1000
+                maxLatency: 1
+                recordVisionData: false
+                useThread: true
+                useThreadsForSensors: true
+                bestEffort: false
+                allSceneObjects: false
+                rangeSensorPrecisionRatio: 2
+                depthError: 0
+                enableHeadLight: true
+                enableAdditionalLights: true
+    - 
+      id: 8
+      name: "add_objects.py"
+      plugin: Python
+      class: PythonScriptItem
+      data: 
+        file: "@JVRC_RTC_DIRECTORY@/launch/add_objects.py"
+        executionOnLoading: true
+        backgroundExecution: false
+    -
+      id: 9
+      name: "ros_service_server.py"
+      plugin: Python
+      class: PythonScriptItem
+      data:
+        file: "@JVRC_RTC_DIRECTORY@/scripts/ros_service_server.py"
+        executionOnLoading: true
+        backgroundExecution: false
+
+views: 
+  - 
+    id: 0
+    name: "CameraImage"
+    plugin: Base
+    class: ImageView
+    mounted: true
+  - 
+    id: 1
+    plugin: Base
+    class: ItemPropertyView
+    mounted: true
+  - 
+    id: 2
+    plugin: Base
+    class: ItemTreeView
+    mounted: true
+    state: 
+      selected: [ 9 ]
+      checked: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ]
+      expanded: [ 1 ]
+  - 
+    id: 3
+    plugin: Base
+    class: MessageView
+    mounted: true
+  - 
+    id: 4
+    plugin: Base
+    class: SceneView
+    mounted: true
+    state: 
+      editMode: true
+      viewpointControlMode: thirdPerson
+      collisionLines: false
+      polygonMode: fill
+      defaultHeadLight: true
+      defaultHeadLightIntensity: 0.75
+      headLightLightingFromBack: false
+      worldLight: true
+      worldLightIntensity: 0.5
+      worldLightAmbient: 0.3
+      additionalLights: true
+      floorGrid: true
+      floorGridSpan: 10
+      floorGridInterval: 0.5
+      xzGridSpan: 10
+      xzGridInterval: 0.5
+      xzGrid: false
+      yzGridSpan: 10
+      yzGridInterval: 0.5
+      texture: true
+      lineWidth: 1
+      pointSize: 1
+      normalVisualization: false
+      normalLength: 0.01
+      coordinateAxes: true
+      showFPS: false
+      enableNewDisplayListDoubleRendering: false
+      useBufferForPicking: true
+      cameras: 
+        - 
+          camera: [ System, Perspective ]
+          isCurrent: true
+          fieldOfView: 0.6978
+          near: 0.01
+          far: 100
+          eye: [ 11.7828093, -8.8897689, 7.27931946 ]
+          direction: [ -0.604984398, 0.718262808, -0.343645772 ]
+          up: [ -0.22138268, 0.262834787, 0.939099347 ]
+        - 
+          camera: [ System, Orthographic ]
+          orthoHeight: 20
+          near: 0.01
+          far: 100
+      backgroundColor: [ 0.100000001, 0.100000001, 0.300000012 ]
+      gridColor: [ 0.899999976, 0.899999976, 0.899999976, 1 ]
+      xzgridColor: [ 0.899999976, 0.899999976, 0.899999976, 1 ]
+      yzgridColor: [ 0.899999976, 0.899999976, 0.899999976, 1 ]
+      dedicatedItemTreeViewChecks: false
+  - 
+    id: 5
+    name: "Task"
+    plugin: Base
+    class: TaskView
+    state: 
+      layoutMode: horizontal
+      isAutoMode: false
+  - 
+    id: 6
+    plugin: Body
+    class: BodyLinkView
+    mounted: true
+    state: 
+      showRotationMatrix: false
+  - 
+    id: 7
+    plugin: Body
+    class: JointSliderView
+    mounted: true
+    state: 
+      showAllJoints: true
+      jointId: false
+      name: true
+      numColumns: 1
+      spinBox: true
+      slider: true
+      labelOnLeft: true
+  - 
+    id: 8
+    plugin: Body
+    class: LinkSelectionView
+    mounted: true
+    state: 
+      listingMode: "Link List"
+  - 
+    id: 10
+    plugin: Python
+    class: PythonConsoleView
+    mounted: true
+toolbars: 
+  "TimeBar": 
+    minTime: 0
+    maxTime: 12000
+    frameRate: 1000
+    playbackFrameRate: 50
+    idleLoopDrivenMode: false
+    currentTime: 0
+    speedScale: 1
+    syncToOngoingUpdates: true
+    autoExpansion: true
+  "KinematicsBar": 
+    mode: AUTO
+    enablePositionDragger: true
+    penetrationBlock: false
+    collisionLinkHighlight: false
+    snapDistance: 0.025
+    penetrationBlockDepth: 0.0005
+    lazyCollisionDetectionMode: true
+  "LeggedBodyBar": 
+    stanceWidth: 0.15
+  "BodyMotionGenerationBar": 
+    autoGenerationForNewBody: true
+    balancer: false
+    autoGeneration: false
+    timeScaleRatio: 1
+    preInitialDuration: 1
+    postFinalDuration: 1
+    onlyTimeBarRange: false
+    makeNewBodyItem: true
+    stealthyStepMode: true
+    stealthyHeightRatioThresh: 2
+    flatLiftingHeight: 0.005
+    flatLandingHeight: 0.005
+    impactReductionHeight: 0.005
+    impactReductionTime: 0.04
+    autoZmp: true
+    minZmpTransitionTime: 0.1
+    zmpCenteringTimeThresh: 0.03
+    zmpTimeMarginBeforeLiftingSpin: 0
+    zmpMaxDistanceFromCenter: 0.02
+    allLinkPositions: false
+    lipSyncMix: false
+    timeToStartBalancer: 0
+    balancerIterations: 2
+    plainBalancerMode: false
+    boundaryConditionType: position
+    boundarySmootherType: quintic
+    boundarySmootherTime: 0.5
+    boundaryCmAdjustment: false
+    boundaryCmAdjustmentTime: 1
+    waistHeightRelaxation: false
+    gravity: 9.8
+    dynamicsTimeRatio: 1
+Body: 
+  "BodyMotionEngine": 
+    updateJointVelocities: false
+  "EditableSceneBody": 
+    editableSceneBodies: 
+      - 
+        bodyItem: 2
+        showCenterOfMass: false
+        showPpcom: false
+        showZmp: false
+      - 
+        bodyItem: 3
+        showCenterOfMass: false
+        showPpcom: false
+        showZmp: false
+      - 
+        bodyItem: 4
+        showCenterOfMass: false
+        showPpcom: false
+        showZmp: false
+    staticModelEditing: false
+  "KinematicFaultChecker": 
+    checkJointPositions: true
+    angleMargin: 0
+    translationMargin: 0
+    checkJointVelocities: true
+    velocityLimitRatio: 100
+    targetJoints: all
+    checkSelfCollisions: true
+    onlyTimeBarRange: false
+OpenRTM: 
+  "deleteUnmanagedRTCsOnStartingSimulation": false
+viewAreas: 
+  - 
+    type: embedded
+    tabs: true
+    contents: 
+      type: splitter
+      orientation: horizontal
+      sizes: [ 326, 1588 ]
+      children: 
+        - 
+          type: splitter
+          orientation: vertical
+          sizes: [ 497, 496 ]
+          children: 
+            - 
+              type: pane
+              views: [ 2 ]
+              current: 2
+            - 
+              type: pane
+              views: [ 1, 8, 9 ]
+              current: 9
+        - 
+          type: splitter
+          orientation: vertical
+          sizes: [ 993, 0 ]
+          children: 
+            - 
+              type: splitter
+              orientation: horizontal
+              sizes: [ 0, 1582 ]
+              children: 
+                - 
+                  type: pane
+                  views: [ 6, 7, 0 ]
+                  current: 6
+                - 
+                  type: pane
+                  views: [ 4 ]
+                  current: 4
+            - 
+              type: pane
+              views: [ 3, 10 ]
+              current: 3
+layoutOfToolBars: 
+  rows: 
+    - 
+      - { name: "FileBar", x: 0, priority: 0 }
+      - { name: "ScriptBar", x: 47, priority: 3 }
+      - { name: "TimeBar", x: 47, priority: 1 }
+      - { name: "SceneBar", x: 1455, priority: 2 }
+      - { name: "SimulationBar", x: 1464, priority: 0 }

--- a/hrpsys_choreonoid_tutorials/config/floor.yaml.in
+++ b/hrpsys_choreonoid_tutorials/config/floor.yaml.in
@@ -1,0 +1,5 @@
+obj1:
+  name: 'VISIBLE_FLOOR'
+  file: '@CHOREONOID_ROOT_DIR@/share/choreonoid-1.7/model/misc/floor.body'
+  translation: [0, 0, -0.1]
+  rotation: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]

--- a/hrpsys_choreonoid_tutorials/launch/choreonoid_jaxon_red_no_controllers.launch
+++ b/hrpsys_choreonoid_tutorials/launch/choreonoid_jaxon_red_no_controllers.launch
@@ -1,0 +1,13 @@
+<launch>
+  <arg name="ENVIRONMENT_YAML" default="$(find hrpsys_choreonoid_tutorials)/config/floor.yaml" />
+  <env name="EXTRA_CHOREONOID_OBJS" value="$(arg ENVIRONMENT_YAML)" />
+
+  <!-- robot dependant settings -->
+  <arg name="PROJECT_FILE" default="$(find hrpsys_choreonoid_tutorials)/config/JAXON_RED_SHM_LOAD_OBJ.cnoid" />
+
+  <!-- choreonoid -->
+  <param name="use_sim_time" value="true"/>
+  <node pkg="hrpsys_choreonoid" type="run_choreonoid.sh" name="choreonoid" output="screen"
+        args="$(arg PROJECT_FILE) --start-simulation"/>
+
+</launch>

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid_shm.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_red_choreonoid_shm.launch
@@ -1,0 +1,50 @@
+<launch>
+  <!-- robot dependant settings -->
+  <arg name="COLLADA_FILE"  default="$(find hrpsys_choreonoid_tutorials)/models/JAXON_JVRC_SENSORS.urdf"/>
+  <arg name="MODEL_FILE" default="$(find jvrc_models)/JAXON_JVRC/JAXON_JVRCmain_hrpsys.wrl"/>
+  <arg name="CONF_FILE" default="$(find hrpsys_choreonoid_tutorials)/models/JAXON_JVRC.conf"/>
+  <arg name="HRPSYS_PY_PKG"  default="hrpsys_ros_bridge_tutorials"/>
+  <arg name="HRPSYS_PY_NAME" default="jaxon_red_hrpsys_config.py" />
+  <arg name="CONTROLLER_CONFIG" default="$(find hrpsys_choreonoid_tutorials)/models/JAXON_JVRC_controller_config.yaml" />
+
+  <!-- hrpsys -->
+  <arg name="hrpsys_opt_rtc_config_args" default=""/>
+  <include file="$(find hrpsys_tools)/launch/hrpsys.launch" >
+    <arg name="CONF_FILE" value="$(arg CONF_FILE)"/>
+    <arg name="PROJECT_FILE" value=""/>
+    <arg name="USE_RTCD" value="true"/>
+    <arg name="SIMULATOR_NAME" value="RobotHardware0"/>
+    <arg name="MODEL_FILE" value="$(arg MODEL_FILE)"/>
+    <arg name="HRPSYS_PY_PKG" value="$(arg HRPSYS_PY_PKG)"/>
+    <arg name="HRPSYS_PY_NAME" default="$(arg HRPSYS_PY_NAME)"/>
+    <arg name="OUTPUT" default="screen"/>
+    <arg name="hrpsys_load_path" default="$(find hrpsys_choreonoid)/lib,$(find hrpsys_trans_bridge)/lib,$(find hrpsys)/lib"/>
+    <arg name="hrpsys_opt_rtc_config_args" value="$(arg hrpsys_opt_rtc_config_args)"/>
+    <arg name="hrpsys_periodic_rate" value="500"/>
+    <arg name="hrpsys_periodic_type" value="ShmTimePeriodicExecutionContext" />
+    <arg name="hrpsys_preload_rtc" value="RobotHardware.so,ShmTimePeriodicExecutionContext.so"/>
+  </include>
+
+  <!-- ros_bridge -->
+  <rosparam command="load" file="$(arg CONTROLLER_CONFIG)" />
+  <include file="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch" >
+    <arg name="MODEL_FILE" default="$(arg MODEL_FILE)" />
+    <arg name="COLLADA_FILE" default="$(arg COLLADA_FILE)" />
+    <arg name="CONF_FILE" default="$(arg CONF_FILE)" />
+    <arg name="SIMULATOR_NAME" default="RobotHardware0" />
+    <arg name="USE_ROBOTHARDWARE" default="true" />
+    <arg name="USE_IMPEDANCECONTROLLER" default="true" />
+    <arg name="USE_WALKING" default="true" />
+    <arg name="USE_ROBOT_POSE_EKF" default="false" />
+    <arg name="USE_SOFTERRORLIMIT" default="true" />
+    <arg name="USE_VELOCITY_OUTPUT" value="true" />
+    <arg name="USE_EMERGENCYSTOPPER" default="true" />
+    <arg name="USE_COLLISIONCHECK" default="true" />
+    <arg name="USE_REFERENCEFORCEUPDATER" value="true" />
+    <arg name="USE_OBJECTCONTACTTURNAROUNDDETECTOR" default="true" />
+    <arg name="USE_DIAGNOSTICS" default="false" />
+    <arg name="periodic_rate" value="100" />
+    <env name="RTC_CONNECTION_CHECK_ONCE" value="true" />
+  </include>
+
+</launch>


### PR DESCRIPTION
このPull Requestは、次のことを可能にするためのものです
1. choreonoidとhrpsysが、OpenRTMPluginのBodyRTCItemではなく、共有メモリで通信するようにする。
2. choreonoidでシミュレーションされたカメラを、OpenRTMPluginのBodyRTCItemではなく、choreonoidから直接ROSで出力するようにする

これによって、次のような利点があります
- ExecutionContextを除いて、実機と全く同じhrpsysやros_bridgeのプログラムを使用することができるようになります。
  - ChoreonoidHrpsysConfigulatorやRobotHardware_choreonoidへの依存がなくなります
- choreonoid OpenRTMPluginへの依存がなくなります
- choreonoidを立ち上げたまま、hrpsysを落としたり立ち上げなおしたりできるようになります。
- カメラ画像をシミュレーションするための設定が簡略化されます

これによって、次のような欠点があります
- hrpsys_trans_bridge及びservo_shm.hを使うため、hrpsys_choreonoidがtrans_systemに依存する
- choreonoidとhrpsysとの同期が、OpenRTMPluginのBodyRTCItemは厳密にとることが可能だったが、ubuntuのOSのスケジューリング等の精度程度になる。今の所、歩行動作が問題なく行えている.

## 先にmergeする必要があるPull Request
https://discourse.choreonoid.org/t/simulatoritem/479/2
https://github.com/jsk-ros-pkg/trans_system/pull/806
https://github.com/jsk-ros-pkg/trans_system/pull/804
https://github.com/start-jsk/rtmros_common/pull/1125

## run sample
1. https://github.com/jsk-ros-pkg/trans_system/#readme のワークスペース構築手順に従う。ただし、各リポジトリはこのPull Request及び上記Pull Requestのブランチにする.
3. terminal 1: choreonoidの立ち上げ
```
roslaunch hrpsys_choreonoid_tutorials choreonoid_jaxon_red_no_controllers.launch
```
4. terminal 2: hrpsysとros bridgeの立ち上げ
```
rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid_shm.launch
```
5. terminal 3 
```
roscd hrpsys_choreonoid_tutorials
roseus ./jaxon_jvrc-interface.l
jaxon_jvrc-init
send *ri* :start-auto-balancer
send *ri* :start-st
send *ri* :go-pos 1 1 90
```

## 関連するリポジトリ(これらからコピーしてきました)
https://github.com/Naoki-Hiraoka/execution_context_shmtime
https://github.com/Naoki-Hiraoka/choreonoid_ros_ext_plugin
https://gitlab.jsk.imi.i.u-tokyo.ac.jp/hiraoka/choreonoid_bridge_shm