### PR TITLE
[hrpsys_choreonoid_tutorials] add floor.yaml

### DIFF
--- a/hrpsys_choreonoid_tutorials/config/floor.yaml
+++ b/hrpsys_choreonoid_tutorials/config/floor.yaml
@@ -1,0 +1,5 @@
+obj1:
+  name: 'VISIBLE_FLOOR'
+  file: '$(find choreonoid)/share/model/misc/floor.body'
+  translation: [0, 0, -0.1]
+  rotation: [[1, 0, 0], [0, 1, 0], [0, 0, 1]]


### PR DESCRIPTION
# 現状
```
rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch LOAD_OBJECTS:=true ENVIRONMENT_YAML:=$(rospack find hrpsys_choreonoid_tutorials)/config/flat.yaml
```
![Screenshot from 2022-10-18 18-53-58](https://user-images.githubusercontent.com/32383525/196398825-b68dba2a-25d0-403d-be9c-f979213811dd.png)

`add_objects.py`を使ってシミュレーション環境を用意するときに、平らな地面の`ENVIRONMENT_YAML`として、上の写真のような、テクスチャ付きの地面(`flat.yaml`)しか用意されていません。

テクスチャ付きの地面は、レンダリングに時間がかかるのか、シミュレーションが遅くなる原因になります。

# With this Pull Request
```
rtmlaunch hrpsys_choreonoid_tutorials jaxon_red_choreonoid.launch LOAD_OBJECTS:=true ENVIRONMENT_YAML:=$(rospack find hrpsys_choreonoid_tutorials)/config/floor.yaml
```
![Screenshot from 2022-10-18 18-53-34](https://user-images.githubusercontent.com/32383525/196398798-e08f96c9-baf6-4dfb-82e9-f3c208892762.png)

上の写真のような、テクスチャ無しの地面(`floor.yaml`)を追加しました。