### PR TITLE
[hrpsys_choreonoid/add_objects.py] fix for python3 (convert bytes to str. comment out OpenRTMPlugin)

### DIFF
--- a/hrpsys_choreonoid/launch/add_objects.py
+++ b/hrpsys_choreonoid/launch/add_objects.py
@@ -2,7 +2,7 @@ from __future__ import print_function ### for python2 compatible with python3
 
 from cnoid.Base import *
 from cnoid.BodyPlugin import *
-from cnoid.OpenRTMPlugin import *
+#from cnoid.OpenRTMPlugin import *
 from cnoid.PythonSimScriptPlugin import *
 import cnoid.Body
 
@@ -46,6 +46,9 @@ def parse_filename(filestr):
         pkgname = ret.group(1)
         #packagepath = commands.getoutput('rospack find %s'%(pkgname))
         packagepath = subprocess.check_output(['rospack', 'find', pkgname])
+        # From python3, bytes needs to be converted to str manually.
+        if not isinstance(packagepath, str):
+            packagepath = packagepath.decode()
         packagepath = packagepath.rstrip('\n')
         filestr = filestr[:ret.start(0)] + packagepath + filestr[ret.end(0):]
 


### PR DESCRIPTION
`add_objects.py`を、最新のchoreonoid1.8(patch・コンパイルオプション無し)でも使用できるようにするための修正です。この変更が無いと、使用することができません。

- python3では`str`型と`bytes`型を区別するので、場合分けを追加しました。
- add_objects.pyはOpenRTMPluginを使用していないにも関わらずOpenRTMPluginをimportしていたので、importしないようにしました。これによって、OpenRTMPluginの設定をしていないデフォルトの状態のchoreonoid1.8でも`add_objects.py`が使えるようになります.

これらの変更後でも、従来のchoreonouid1.7 + patchで`rtmlaunch hrpsys_coreonoid_tutorials jaxon_red_choreonoid.launch LOAD_OBJECTS:=true`が問題なく立ち上がることを確認しました。